### PR TITLE
LTD-776: Edifact file generation remediation changes

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -1,3 +1,14 @@
+LITE_HMRC_LICENCE_TYPE_MAPPING = {
+    "siel": "SIE",
+    "sicl": "SIE",
+    "sitl": "SIE",
+    "oiel": "OIE",
+    "ogel": "OGE",
+    "ogcl": "OGE",
+    "ogtl": "OGE",
+}
+
+
 class LicenceActionEnum:
     INSERT = "insert"
     CANCEL = "cancel"

--- a/mail/libraries/builders.py
+++ b/mail/libraries/builders.py
@@ -125,7 +125,7 @@ def build_licence_data_mail(licences) -> Mail:
 
 def build_licence_data_file(licences, run_number) -> (str, str):
     now = timezone.now()
-    file_name = "SPIRE_live_CHIEF_licenceData_{}_{:04d}{:02d}{:02d}{:02d}{:02d}".format(
+    file_name = "SPIRE_LIVE_CHIEF_licenceData_{}_{:04d}{:02d}{:02d}{:02d}{:02d}".format(
         run_number, now.year, now.month, now.day, now.hour, now.minute
     )
 

--- a/mail/libraries/builders.py
+++ b/mail/libraries/builders.py
@@ -125,7 +125,7 @@ def build_licence_data_mail(licences) -> Mail:
 
 def build_licence_data_file(licences, run_number) -> (str, str):
     now = timezone.now()
-    file_name = "SPIRE_LIVE_CHIEF_licenceData_{}_{:04d}{:02d}{:02d}{:02d}{:02d}".format(
+    file_name = "CHIEF_LIVE_SPIRE_licenceData_{}_{:04d}{:02d}{:02d}{:02d}{:02d}".format(
         run_number, now.year, now.month, now.day, now.hour, now.minute
     )
 

--- a/mail/libraries/edifact_validator.py
+++ b/mail/libraries/edifact_validator.py
@@ -1,0 +1,237 @@
+from mail.enums import LicenceActionEnum, LITE_HMRC_LICENCE_TYPE_MAPPING
+
+FILE_HEADER_FIELDS_LEN = 8
+LICENCE_TRANSACTION_HEADER_FIELDS_LEN = 9
+PERMITTED_TRADER_HEADER_FIELDS_LEN = 13
+COUNTRY_FIELDS_LEN = 5
+FOREIGN_TRADER_FIELDS_LEN = 10
+LICENCE_LINE_FIELDS_LEN = 13
+FILE_TRAILER_FIELDS_LEN = 3
+
+VALID_ACTIONS_TO_HMRC = [choice[0] for choice in LicenceActionEnum.choices]
+VALID_LICENCE_TYPES = LITE_HMRC_LICENCE_TYPE_MAPPING.values()
+ALLOWED_COUNTRY_USE_VALUES = ["D", "E", "O", "P", "R", "S"]
+CONTROLLED_BY_VALUES = ["B", "O", "Q", "V"]
+
+
+def validate_file_header(record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+
+    if len(tokens) != FILE_HEADER_FIELDS_LEN:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if int(tokens[0]) != 1:
+        errors.append({record_type: f"{record_type} is not in the first line"})
+
+    if tokens[1] != "fileHeader":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    if tokens[2] == tokens[3]:
+        errors.append({record_type: "Source and destination are the same"})
+
+    if tokens[4] not in ["licenceData", "licenceReply", "usageData", "usageReply"]:
+        errors.append({record_type: f"{record_type} contains invalid data identifier"})
+
+    if tokens[7] not in ["Y", "N"]:
+        errors.append({record_type: f"{record_type} contains invalid reset run number indicator"})
+
+    return errors
+
+
+def validate_licence_transaction_header(data_identifier, record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+    action = tokens[3]
+
+    if len(tokens) != LICENCE_TRANSACTION_HEADER_FIELDS_LEN:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if tokens[1] != "licence":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    if data_identifier in ["licenceData"] and action not in VALID_ACTIONS_TO_HMRC:
+        errors.append({record_type: f"Invalid action {action} for the data identifier {data_identifier}"})
+
+    if tokens[5] not in VALID_LICENCE_TYPES:
+        errors.append({record_type: f"Invalid licence type {tokens[5]} in the record"})
+
+    if tokens[6] != "E":
+        errors.append({record_type: "licence transaction header is not of Export type"})
+
+    return errors
+
+
+def validate_permitted_trader(record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+    TURN = tokens[2]
+    rpa_trader_id = tokens[3]
+
+    if len(tokens) != PERMITTED_TRADER_HEADER_FIELDS_LEN:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if tokens[1] != "trader":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    if TURN == "" and rpa_trader_id == "":
+        errors.append({record_type: "RPA Trader Id must not be empty when TURN is empty"})
+
+    if int(tokens[5]) < int(tokens[4]):
+        errors.append({record_type: "Invalid start and end dates for the licence"})
+
+    return errors
+
+
+def validate_country(record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+
+    if len(tokens) != COUNTRY_FIELDS_LEN:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if tokens[1] != "country":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    if tokens[2] and tokens[3]:
+        errors.append({record_type: "Both country code and group cannot be valid in the same record"})
+
+    if tokens[4] not in ALLOWED_COUNTRY_USE_VALUES:
+        errors.append({record_type: f"Invalid country use value {tokens[4]}"})
+
+    return errors
+
+
+def validate_foreign_trader(record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+
+    if len(tokens) != FOREIGN_TRADER_FIELDS_LEN:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if tokens[1] != "foreignTrader":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    return errors
+
+
+def validate_restrictions(record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+
+    if len(tokens) != 3:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if tokens[1] != "restrictions":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    return errors
+
+
+def validate_licence_product_line(record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+    controlled_by = tokens[8]
+
+    if len(tokens) != LICENCE_LINE_FIELDS_LEN:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if tokens[1] != "line":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    if tokens[7] == "":
+        errors.append({record_type: "Product description cannot be empty"})
+
+    if controlled_by not in CONTROLLED_BY_VALUES:
+        errors.append({record_type: "Invalid controlled by value"})
+
+    if len(tokens[10]) != 3:
+        errors.append({record_type: "Quantity unit field should be of 3 characters wide"})
+
+    return errors
+
+
+def validate_end_line(record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+
+    if len(tokens) != 4:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if tokens[1] != "end":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    return errors
+
+
+def validate_file_trailer(record):
+    errors = []
+    tokens = record.split("\\")
+    record_type = tokens[1]
+
+    if len(tokens) != FILE_TRAILER_FIELDS_LEN:
+        errors.append({record_type: f"{record_type} doesn't contain all necessary values"})
+        return errors
+
+    if tokens[1] != "fileTrailer":
+        errors.append({record_type: f"Invalid file header tag {tokens[1]}"})
+
+    return errors
+
+
+def validate_edifact_file(file_data):
+    """
+    Validates the content as per the DES236 specification
+
+    Validates each line and returns the list of discrepencies
+    """
+    file_lines = [line for line in file_data.split("\n") if line]
+
+    errors = []
+    data_identifier = ""
+    for line in file_lines[:]:
+        line_errors = list()
+        tokens = line.split("\\")
+        record_type = tokens[1]
+
+        if record_type == "fileHeader":
+            data_identifier = tokens[4]
+            line_errors = validate_file_header(line)
+        elif record_type == "licence":
+            line_errors = validate_licence_transaction_header(data_identifier, line)
+        elif record_type == "trader":
+            line_errors = validate_permitted_trader(line)
+        elif record_type == "country":
+            line_errors = validate_country(line)
+        elif record_type == "foreignTrader":
+            line_errors = validate_foreign_trader(line)
+        elif record_type == "restrictions":
+            line = validate_restrictions(line)
+        elif record_type == "line":
+            line_errors = validate_licence_product_line(line)
+        elif record_type == "end":
+            line_errors = validate_end_line(line)
+        elif record_type == "fileTrailer":
+            line_errors = validate_file_trailer(line)
+        else:
+            line_errors.append(f"Invalid record type {record_type}")
+
+        errors.extend(line_errors)
+
+    return errors

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -9,7 +9,7 @@ from mail.models import OrganisationIdMapping, GoodIdMapping, LicencePayload
 def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
     now = timezone.now()
     time_stamp = "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
-    edifact_file = "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\{}\\{}".format(time_stamp, run_number)
+    edifact_file = "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\{}\\{}\\Y".format(time_stamp, run_number)
     i = 1
     for licence in licences:
         licence_payload = licence.data

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -6,49 +6,65 @@ from mail.libraries.helpers import get_country_id
 from mail.models import OrganisationIdMapping, GoodIdMapping, LicencePayload
 
 
+LITE_HMRC_LICENCE_TYPE_MAPPING = {
+    "siel": "SIE",
+    "sicl": "SIE",
+    "sitl": "SIE",
+    "oiel": "OIE",
+    "oiel": "OIE",
+    "ogel": "OGE",
+    "ogcl": "OGE",
+    "ogtl": "OGE",
+}
+
+
 def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
     now = timezone.now()
     time_stamp = "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
+
     edifact_file = "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\{}\\{}\\Y".format(time_stamp, run_number)
-    i = 1
+
+    line_no = 1
     for licence in licences:
         licence_payload = licence.data
-        start_line = i
-        i += 1
+        licence_type = LITE_HMRC_LICENCE_TYPE_MAPPING.get(licence_payload.get("type"))
+        start_line = line_no
+        line_no += 1
+
         if licence.action == LicenceActionEnum.UPDATE:
             old_reference = licence.old_reference
             old_payload = LicencePayload.objects.get(reference=old_reference).data
             edifact_file += "\n{}\\licence\\{}\\{}\\{}\\{}\\{}\\{}\\{}".format(
-                i,
+                line_no,
                 get_transaction_reference(old_reference),  # transaction_reference
                 "cancel",
                 old_reference,
-                licence_payload.get("type"),
-                "E",
+                licence_type,
+                "E",  # Export use
                 old_payload.get("start_date").replace("-", ""),
                 old_payload.get("end_date").replace("-", ""),
             )
-            i += 1
-            edifact_file += "\n{}\\end\\licence\\{}".format(i, i - start_line)
-            start_line = i
-            i += 1
+            line_no += 1
+            edifact_file += "\n{}\\end\\licence\\{}".format(line_no, line_no - start_line)
+            start_line = line_no
+            line_no += 1
             edifact_file += "\n{}\\licence\\{}\\{}\\{}\\{}\\{}\\{}\\{}".format(
-                i,
+                line_no,
                 get_transaction_reference(licence.reference),  # transaction_reference
                 "insert",
                 licence.reference,
-                licence_payload.get("type"),
-                "E",
+                licence_type,
+                "E",  # Export use
                 licence_payload.get("start_date").replace("-", ""),
                 licence_payload.get("end_date").replace("-", ""),
             )
         else:
             edifact_file += "\n{}\\licence\\{}\\{}\\{}\\{}\\{}\\{}\\{}".format(
-                i,
+                line_no,
                 get_transaction_reference(licence.reference),  # transaction_reference
                 licence.action,
                 licence.reference,
-                licence_payload.get("type"),
+                licence_type,
                 "E",
                 licence_payload.get("start_date").replace("-", ""),
                 licence_payload.get("end_date").replace("-", ""),
@@ -58,9 +74,9 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
             org_mapping, _ = OrganisationIdMapping.objects.get_or_create(
                 lite_id=trader["id"], defaults={"lite_id": trader["id"]}
             )
-            i += 1
+            line_no += 1
             edifact_file += "\n{}\\trader\\{}\\{}\\{}\\{}\\{}\\{}\\{}\\{}\\{}\\{}\\{}".format(
-                i,
+                line_no,
                 "",  # turn
                 org_mapping.rpa_trader_id,
                 licence_payload.get("start_date").replace("-", ""),
@@ -74,19 +90,27 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
                 trader.get("address").get("postcode"),
             )
             # Uses "D" for licence use because lite only sends allowed countries, to use E would require changes on the API
-            if licence_payload.get("country_group"):
-                i += 1
-                edifact_file += "\n{}\\country\\\\{}\\{}".format(i, licence_payload.get("country_group"), "D")
-            elif licence_payload.get("countries"):
-                for country in licence_payload.get("countries"):
-                    country_id = get_country_id(country)
-                    i += 1
-                    edifact_file += "\n{}\\country\\{}\\\\{}".format(i, country_id, "D")
+            if licence_payload.get("type") in LicenceTypeEnum.OPEN_LICENCES:
+                if licence_payload.get("country_group"):
+                    line_no += 1
+                    edifact_file += "\n{}\\country\\\\{}\\{}".format(line_no, licence_payload.get("country_group"), "D")
+                elif licence_payload.get("countries"):
+                    for country in licence_payload.get("countries"):
+                        country_id = get_country_id(country)
+                        line_no += 1
+                        edifact_file += "\n{}\\country\\{}\\\\{}".format(line_no, country_id, "D")
+            elif licence_payload.get("type") in LicenceTypeEnum.STANDARD_LICENCES:
+                if licence_payload.get("end_user"):
+                    # In the absence of country_group or countries use country of End user
+                    country_id = licence_payload.get("end_user").get("address").get("country").get("id")
+                    line_no += 1
+                    edifact_file += "\n{}\\country\\{}\\\\{}".format(line_no, country_id, "D")
+
             if licence_payload.get("end_user"):
                 trader = licence_payload.get("end_user")
-                i += 1
+                line_no += 1
                 edifact_file += "\n{}\\foreignTrader\\{}\\{}\\{}\\{}\\{}\\{}\\{}\\{}".format(
-                    i,
+                    line_no,
                     trader.get("name"),
                     trader.get("address").get("line_1"),
                     trader.get("address").get("line_2", ""),
@@ -96,33 +120,33 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
                     trader.get("address").get("postcode", ""),
                     trader.get("address").get("country").get("id"),
                 )
-            i += 1
-            edifact_file += "\n{}\\restrictions\\{}".format(i, "Provisos may apply please see licence")
-            g = 0
+            line_no += 1
+            edifact_file += "\n{}\\restrictions\\{}".format(line_no, "Provisos may apply please see licence")
             if licence_payload.get("goods") and licence_payload.get("type") in LicenceTypeEnum.STANDARD_LICENCES:
-                for commodity in licence_payload.get("goods"):
-                    i += 1
-                    g += 1
+                for g, commodity in enumerate(licence_payload.get("goods"), start=1):
+                    line_no += 1
                     GoodIdMapping.objects.get_or_create(
                         lite_id=commodity["id"], licence_reference=licence.reference, line_number=g
                     )
-                    edifact_file += "\n{}\\line\\{}\\\\\\\\\\{}\\Q\\{}\\{}".format(
-                        i,
+                    controlled_by = "Q"  # usage is controlled by quantity only
+                    edifact_file += "\n{}\\line\\{}\\\\\\\\\\{}\\{}\\\\{:03d}\\\\{}".format(
+                        line_no,
                         g,
-                        commodity.get("description"),
+                        commodity.get("name"),
+                        controlled_by,
                         UnitMapping.convert(commodity.get("unit")),
                         int(commodity.get("quantity")) if commodity.get("unit") == "NAR" else commodity.get("quantity"),
                     )
             if licence_payload.get("type") in LicenceTypeEnum.OPEN_LICENCES:
-                i += 1
-                edifact_file += "\n{}\\line\\1\\\\\\\\\\Open Licence goods - see actual licence for information\\".format(
-                    i
+                line_no += 1
+                edifact_file += (
+                    "\n{}\\line\\1\\\\\\\\\\Open Licence goods - see actual licence for information\\".format(line_no)
                 )
-        i += 1
-        edifact_file += "\n{}\\end\\licence\\{}".format(i, i - start_line)
-    i += 1
+        line_no += 1
+        edifact_file += "\n{}\\end\\licence\\{}".format(line_no, line_no - start_line)
+    line_no += 1
     edifact_file += "\n{}\\fileTrailer\\{}".format(
-        i, licences.count() + licences.filter(action=LicenceActionEnum.UPDATE).count()
+        line_no, licences.count() + licences.filter(action=LicenceActionEnum.UPDATE).count()
     )
     return edifact_file
 

--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -133,7 +133,8 @@ class UsageUpdateMailSerializer(serializers.ModelSerializer):
 
 
 class GoodSerializer(serializers.Serializer):
-    description = serializers.CharField(max_length=2000, allow_blank=False)
+    name = serializers.CharField()
+    description = serializers.CharField(max_length=2000, allow_blank=True)
     quantity = serializers.DecimalField(decimal_places=3, max_digits=13)
     unit = serializers.CharField()
 

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -25,6 +25,7 @@ from mail.enums import ReceptionStatusEnum, ReplyStatusEnum
 from mail.libraries.builders import build_licence_data_mail
 from mail.libraries.data_processors import build_request_mail_message_dto
 from mail.libraries.mailbox_service import send_email
+from mail.libraries.lite_to_edifact_converter import EdifactValidationError
 from mail.libraries.routing_controller import check_and_route_emails
 from mail.libraries.routing_controller import update_mail, send
 from mail.libraries.usage_data_decomposition import build_json_payload_from_data_blocks, split_edi_data_by_id
@@ -219,6 +220,8 @@ def send_licence_data_to_hmrc():
             send(server, mail_dto)
             update_mail(mail, mail_dto)
             licences.update(is_processed=True)
+    except EdifactValidationError as err:  # noqa
+        raise err
     except Exception as exc:  # noqa
         logging.error(
             f"An unexpected error occurred when sending LITE licence updates to HMRC -> {type(exc).__name__}: {exc}"

--- a/mail/tests/files/licence_payload_file
+++ b/mail/tests/files/licence_payload_file
@@ -29,7 +29,8 @@
       "goods": [
           {
               "id": "f95ded2a-354f-46f1-a572-c7f97d63bed1",
-              "description": "finally",
+              "name": "Sporting shotgun",
+              "description": "",
               "unit": "NAR",
               "quantity": 10.0
           }

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -5,10 +5,15 @@ from django.utils import timezone
 from parameterized import parameterized
 
 from mail.enums import LicenceActionEnum
-from mail.libraries.lite_to_edifact_converter import licences_to_edifact, get_transaction_reference
+from mail.libraries.lite_to_edifact_converter import (
+    licences_to_edifact,
+    get_transaction_reference,
+    EdifactValidationError,
+)
 from mail.models import LicencePayload, Mail, OrganisationIdMapping, GoodIdMapping
 from mail.tasks import send_licence_data_to_hmrc
 from mail.tests.libraries.client import LiteHMRCTestClient
+from mail.libraries import edifact_validator
 
 
 class LicenceToEdifactTests(LiteHMRCTestClient):
@@ -131,3 +136,124 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
         )
 
         self.assertEqual(result, expected)
+
+    def test_edifact_gen_raises_exception_on_errors(self):
+        licence = LicencePayload.objects.get()
+        licence.data["type"] = "INVALID_TYPE"
+        licence.save()
+
+        with self.assertRaises(EdifactValidationError) as context:
+            licences_to_edifact(LicencePayload.objects.filter(is_processed=False), 1234)
+
+
+class LicenceToEdifactValidationTests(LiteHMRCTestClient):
+    @parameterized.expand(
+        [
+            ("1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\202104090304\\96839\\Y", 0),
+            ("1\\fileHeader\\SPIRE\\SPIRE\\licenceData\\202104090304\\96839\\Y", 1),
+            ("1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\202104090304\\96839", 1),
+            ("1\\fileHeaders\\SPIRE\\CHIEF\\licenceUpdate\\202104090304\\96839\\Y", 2),
+            ("1\\fileHeader\\SPIRE\\CHIEF\\licenceUpdate\\202104090304\\96839\\T", 2),
+        ]
+    )
+    def test_file_header_validation(self, header, num_errors):
+        errors = edifact_validator.validate_file_header(header)
+        self.assertEqual(len(errors), num_errors)
+
+    @parameterized.expand(
+        [
+            ("2\\licence\\20210000006TA\\insert\\GBSIEL/2021/0000006/T/A\\SIE\\E\\20210408\\20220408", 0),
+            ("2\\licences\\20210000006TA\\insert\\GBSIEL/2021/0000006/T/A\\SIE\\E\\20210408\\20220408", 1),
+            ("2\\licences\\20210000006TA\\add\\GBSIEL/2021/0000006/T/A\\SIE\\E\\20210408\\20220408", 2),
+            ("2\\licence\\20210000006TA\\insert\\GBSIEL/2021/0000006/T/A\\SIEL\\E\\20210408\\20220408", 1),
+            ("2\\licence\\20210000006TA\\insert\\GBSIEL/2021/0000006/T/A\\SIEL\\T\\20210408\\20220408", 2),
+        ]
+    )
+    def test_licence_transaction_header_validation(self, licence_tx_line, num_errors):
+        errors = edifact_validator.validate_licence_transaction_header("licenceData", licence_tx_line)
+        self.assertEqual(len(errors), num_errors)
+
+    @parameterized.expand(
+        [
+            (
+                "3\\trader\\\\6\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2CD",
+                0,
+            ),
+            (
+                "3\\traders\\\\6\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2CD",
+                1,
+            ),
+            (
+                "3\\trader\\\\\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2CD",
+                1,
+            ),
+            (
+                "3\\trader\\\\\\20210408\\20200408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2CD",
+                2,
+            ),
+        ]
+    )
+    def test_permitted_trader_validation(self, line, num_errors):
+        errors = edifact_validator.validate_permitted_trader(line)
+        self.assertEqual(len(errors), num_errors)
+
+    @parameterized.expand(
+        [
+            ("4\\country\\AU\\\\D", 0),
+            ("4\\country\\AU\\", 1),
+            ("4\\country\\AU\\\\T", 1),
+            ("4\\country_id\\AU\\AU\\D", 2),
+        ]
+    )
+    def test_country_validation(self, line, num_errors):
+        errors = edifact_validator.validate_country(line)
+        self.assertEqual(len(errors), num_errors)
+
+    @parameterized.expand(
+        [
+            ("5\\foreignTrader\\Test party\\1234\\\\\\\\\\\\AU", 0),
+            ("5\\foreignTrader\\Test party\\1234\\\\\\\\\\", 1),
+            ("5\\foreignTraders\\Test party\\1234\\\\\\\\\\\\AU", 1),
+        ]
+    )
+    def test_foreign_trader_validation(self, line, num_errors):
+        errors = edifact_validator.validate_foreign_trader(line)
+        self.assertEqual(len(errors), num_errors)
+
+    @parameterized.expand(
+        [
+            ("6\\restrictions\\Provisos may apply please see licence", 0),
+            ("6\\restrictions", 1),
+            ("6\\restrictionsline\\Provisos may apply please see licence", 1),
+        ]
+    )
+    def test_restrictions_validation(self, line, num_errors):
+        errors = edifact_validator.validate_restrictions(line)
+        self.assertEqual(len(errors), num_errors)
+
+    @parameterized.expand(
+        [
+            ("7\\line\\1\\\\\\\\\\Rifle\\Q\\\\030\\\\4", 0),
+            ("7\\line\\1\\\\\\\\\\Rifle\\Q\\\\030\\", 1),
+            ("7\\lines\\1\\\\\\\\\\Rifle\\Q\\\\030\\\\4", 1),
+            ("7\\line\\1\\\\\\\\\\Rifle\\T\\\\30\\\\4", 2),
+            ("7\\lines\\1\\\\\\\\\\\\Q\\\\030\\\\4", 2),
+        ]
+    )
+    def test_licence_product_line_validation(self, line, num_errors):
+        errors = edifact_validator.validate_licence_product_line(line)
+        self.assertEqual(len(errors), num_errors)
+
+    @parameterized.expand(
+        [("10\\end\\licence\\9", 0), ("10\\end\\licence", 1), ("10\\ending\\licence\\9", 1),]
+    )
+    def test_end_line_validation(self, line, num_errors):
+        errors = edifact_validator.validate_end_line(line)
+        self.assertEqual(len(errors), num_errors)
+
+    @parameterized.expand(
+        [("11\\fileTrailer\\1", 0), ("11\\fileTrailer", 1), ("11\\fileTrailers\\1", 1),]
+    )
+    def test_file_trailer_validation(self, line, num_errors):
+        errors = edifact_validator.validate_file_trailer(line)
+        self.assertEqual(len(errors), num_errors)

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -41,7 +41,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
         expected = (
             "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\"
             + "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
-            + "\\1234"
+            + "\\1234\\Y"
             + "\n2\\licence\\20200000001P\\insert\\GBSIEL/2020/0000001/P\\siel\\E\\20200602\\20220602"
             + f"\n3\\trader\\\\{org_mapping.rpa_trader_id}\\20200602\\20220602\\Organisation\\might\\248 James Key Apt. 515\\Apt. 942\\West Ashleyton\\Tennessee\\99580"
             + "\n4\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
@@ -95,7 +95,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
         expected = (
             "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\"
             + "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
-            + "\\1234"
+            + "\\1234\\Y"
             + "\n2\\licence\\20200000001P\\cancel\\GBSIEL/2020/0000001/P\\siel\\E\\20200602\\20220602"
             + "\n3\\end\\licence\\2"
             + "\n4\\licence\\20200000001Pa\\insert\\GBSIEL/2020/0000001/P/a\\siel\\E\\20200602\\20220703"
@@ -122,7 +122,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
         expected = (
             "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\"
             + "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
-            + "\\1234"
+            + "\\1234\\Y"
             + "\n2\\licence\\20200000001P\\cancel\\GBSIEL/2020/0000001/P\\siel\\E\\20200602\\20220602"
             + "\n3\\end\\licence\\2"
             + "\n4\\fileTrailer\\1"

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -42,13 +42,14 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\"
             + "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
             + "\\1234\\Y"
-            + "\n2\\licence\\20200000001P\\insert\\GBSIEL/2020/0000001/P\\siel\\E\\20200602\\20220602"
+            + "\n2\\licence\\20200000001P\\insert\\GBSIEL/2020/0000001/P\\SIE\\E\\20200602\\20220602"
             + f"\n3\\trader\\\\{org_mapping.rpa_trader_id}\\20200602\\20220602\\Organisation\\might\\248 James Key Apt. 515\\Apt. 942\\West Ashleyton\\Tennessee\\99580"
-            + "\n4\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
-            + "\n5\\restrictions\\Provisos may apply please see licence"
-            + "\n6\\line\\1\\\\\\\\\\finally\\Q\\30\\10"
-            + "\n7\\end\\licence\\6"
-            + "\n8\\fileTrailer\\1"
+            + "\n4\\country\\GB\\\\D"
+            + "\n5\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
+            + "\n6\\restrictions\\Provisos may apply please see licence"
+            + "\n7\\line\\1\\\\\\\\\\Sporting shotgun\\Q\\\\030\\\\10"
+            + "\n8\\end\\licence\\7"
+            + "\n9\\fileTrailer\\1"
         )
 
         self.assertEqual(result, expected)
@@ -96,15 +97,16 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\"
             + "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
             + "\\1234\\Y"
-            + "\n2\\licence\\20200000001P\\cancel\\GBSIEL/2020/0000001/P\\siel\\E\\20200602\\20220602"
+            + "\n2\\licence\\20200000001P\\cancel\\GBSIEL/2020/0000001/P\\SIE\\E\\20200602\\20220602"
             + "\n3\\end\\licence\\2"
-            + "\n4\\licence\\20200000001Pa\\insert\\GBSIEL/2020/0000001/P/a\\siel\\E\\20200602\\20220703"
+            + "\n4\\licence\\20200000001Pa\\insert\\GBSIEL/2020/0000001/P/a\\SIE\\E\\20200602\\20220703"
             + f"\n5\\trader\\\\{org_mapping.rpa_trader_id}\\20200602\\20220703\\Organisation\\might\\248 James Key Apt. 515\\Apt. 942\\West Ashleyton\\Tennessee\\99580"
-            + "\n6\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
-            + "\n7\\restrictions\\Provisos may apply please see licence"
-            + "\n8\\line\\1\\\\\\\\\\finally\\Q\\30\\15"
-            + "\n9\\end\\licence\\6"
-            + "\n10\\fileTrailer\\2"
+            + "\n6\\country\\GB\\\\D"
+            + "\n7\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
+            + "\n8\\restrictions\\Provisos may apply please see licence"
+            + "\n9\\line\\1\\\\\\\\\\Sporting shotgun\\Q\\\\030\\\\15"
+            + "\n10\\end\\licence\\7"
+            + "\n11\\fileTrailer\\2"
         )
 
         self.assertEqual(result, expected)
@@ -123,7 +125,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\"
             + "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
             + "\\1234\\Y"
-            + "\n2\\licence\\20200000001P\\cancel\\GBSIEL/2020/0000001/P\\siel\\E\\20200602\\20220602"
+            + "\n2\\licence\\20200000001P\\cancel\\GBSIEL/2020/0000001/P\\SIE\\E\\20200602\\20220602"
             + "\n3\\end\\licence\\2"
             + "\n4\\fileTrailer\\1"
         )


### PR DESCRIPTION
## Change description

Update edifact file generation as per specification
    
Following things are fixed as per Spec DES236,
 - include reset run number indicator in header
 - Update the licence types as required by spec
 - include country line according to licence type
 - Fix licence line data as per spec
     - pad quantity unit with leading zeros to make it 3 char wide string
    
Update tests

Add validator to ensure file content is as per specification.
Helper functions check each line for expected fields and returns list of errors.
