### PR TITLE
LTD-787: Edifact address line fixes

### DIFF
--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -17,7 +17,8 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
     now = timezone.now()
     time_stamp = "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
 
-    edifact_file = "1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\{}\\{}\\Y".format(time_stamp, run_number)
+    reset_run_number_indicator = "Y"
+    edifact_file = f"1\\fileHeader\\SPIRE\\CHIEF\\licenceData\\{time_stamp}\\{run_number}\\{reset_run_number_indicator}"
 
     line_no = 1
     for licence in licences:

--- a/mail/tests/files/licence_payload_file
+++ b/mail/tests/files/licence_payload_file
@@ -14,8 +14,8 @@
               "line_2": "248 James Key Apt. 515",
               "line_3": "Apt. 942",
               "line_4": "West Ashleyton",
-              "line_5": "Tennessee",
-              "postcode": "99580",
+              "line_5": "Farnborough",
+              "postcode": "GU40 2LX",
               "country": {"id": "GB", "name": "United Kingdom"}
           }
       },

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -176,20 +176,36 @@ class LicenceToEdifactValidationTests(LiteHMRCTestClient):
     @parameterized.expand(
         [
             (
-                "3\\trader\\\\6\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2CD",
+                "3\\trader\\\\6\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2BD",
                 0,
             ),
             (
-                "3\\traders\\\\6\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2CD",
+                "3\\traders\\\\6\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2BD",
                 1,
             ),
             (
-                "3\\trader\\\\\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2CD",
+                "3\\trader\\\\\\20210408\\20220408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2BD",
                 1,
             ),
             (
-                "3\\trader\\\\\\20210408\\20200408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2CD",
+                "3\\trader\\\\\\20210408\\20200408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2BD",
                 2,
+            ),
+            (
+                "3\\trader\\\\\\20210408\\20200408\\ABC Test\\Test Location\\windsor house\\\\Windsor\\Surrey\\Islington",
+                3,
+            ),
+            (
+                "3\\trader\\\\6\\20210408\\20220408\\Very long organisation name to trigger validation error, max length is 80 characters\\Test Location\\windsor house\\\\Windsor\\Surrey\\AB1 2BD",
+                1,
+            ),
+            (
+                "3\\trader\\\\6\\20210408\\20220408\\Very long organisation name to trigger validation error, max length is 80 characters\\This is a very long address line to trigger error\\windsor house\\\\Windsor\\Surrey\\AB1 2BD",
+                2,
+            ),
+            (
+                "3\\trader\\\\6\\20210408\\20220408\\Very long organisation name to trigger validation error, max length is 80 characters\\This is a very long address line to trigger error\\windsor house\\\\Windsor\\Surrey\\INVALID POSTCODE",
+                3,
             ),
         ]
     )


### PR DESCRIPTION
## Change description

The length of each address line has a limit as per specification. This PR updates the generation code to validate for these limits and report errors accordingly.

The foreign trader address is currently captured as a single text field and we cannot control the format in which the user provides this address. To stick to the limits as per spec this address is split into chunks and the file is generated accordingly.

Updated tests and added new ones to test the new functionality.