### PR TITLE
LTD-787: Add missing datetime attribute while building EmailMessageDto

### DIFF
--- a/mail/libraries/builders.py
+++ b/mail/libraries/builders.py
@@ -1,4 +1,6 @@
 import logging
+
+from datetime import datetime
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -53,7 +55,7 @@ def build_request_mail_message_dto(mail: Mail) -> EmailMessageDto:
         run_number=run_number,
         sender=sender,
         receiver=receiver,
-        date="",
+        date=datetime.now(),
         subject=attachment[0],
         body=None,
         attachment=attachment,
@@ -118,6 +120,7 @@ def build_reply_mail_message_dto(mail) -> EmailMessageDto:
         sender=sender,
         receiver=receiver,
         subject=attachment[0],
+        date=datetime.now(),
         body=None,
         attachment=attachment,
         raw_data=None,

--- a/mail/tests/test_data_processors.py
+++ b/mail/tests/test_data_processors.py
@@ -1,5 +1,6 @@
 import logging
 
+from datetime import datetime
 from django.test import tag
 from rest_framework.exceptions import ValidationError
 
@@ -72,6 +73,7 @@ class TestDataProcessors(LiteHMRCTestClient):
         self.assertEqual("ILBDOTI_live_CHIEF_licenceReply_49543_201902080025", self.mail.edi_filename)
         self.assertEqual("ILBDOTI_live_CHIEF_licenceReply_49543_201902080025", self.mail.edi_filename)
         self.assertEqual(dto.receiver, SPIRE_ADDRESS)
+        self.assertTrue(isinstance(dto.date, datetime))
         self.assertEqual(dto.body, None)
         self.assertEqual(dto.raw_data, None)
 


### PR DESCRIPTION
Current datetime is used as date