### PR TITLE
LTD-1088: Expose Mail queue status to Sentry periodically

### DIFF
--- a/mail/tests/test_select_email_for_sending.py
+++ b/mail/tests/test_select_email_for_sending.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from django.test import tag
 from unittest import mock
 
@@ -145,6 +146,7 @@ class EmailSelectTests(LiteHMRCTestClient):
             edi_filename=filename,
             edi_data=mail_body,
             status=ReceptionStatusEnum.PENDING,
+            sent_at=datetime.now(timezone.utc),
         )
         LicenceData.objects.create(
             mail=pending_mail,


### PR DESCRIPTION
## Change description

During every polling session export the queue status to Sentry so that we
can check the status without logging into the mailboxes.