### PR TITLE
Some ideas on generating EDIFACT from license

### DIFF
--- a/mail/libraries/edifact_validator.py
+++ b/mail/libraries/edifact_validator.py
@@ -269,34 +269,38 @@ def validate_edifact_file(file_data):
     file_lines = [line for line in file_data.split("\n") if line]
 
     errors = []
-    data_identifier = ""
     for line in file_lines[:]:
-        line_errors = list()
-        tokens = line.split("\\")
-        record_type = tokens[1]
-
-        if record_type == "fileHeader":
-            data_identifier = tokens[4]
-            line_errors = validate_file_header(line)
-        elif record_type == "licence":
-            line_errors = validate_licence_transaction_header(data_identifier, line)
-        elif record_type == "trader":
-            line_errors = validate_permitted_trader(line)
-        elif record_type == "country":
-            line_errors = validate_country(line)
-        elif record_type == "foreignTrader":
-            line_errors = validate_foreign_trader(line)
-        elif record_type == "restrictions":
-            line = validate_restrictions(line)
-        elif record_type == "line":
-            line_errors = validate_licence_product_line(line)
-        elif record_type == "end":
-            line_errors = validate_end_line(line)
-        elif record_type == "fileTrailer":
-            line_errors = validate_file_trailer(line)
-        else:
-            line_errors.append(f"Invalid record type {record_type}")
-
+        line_errors = validate_edifact_line(line)
         errors.extend(line_errors)
-
     return errors
+
+
+def validate_edifact_line(line):
+    line_errors = []
+    data_identifier = ""
+    tokens = line.split("\\")
+    record_type = tokens[1]
+
+    if record_type == "fileHeader":
+        data_identifier = tokens[4]
+        line_errors = validate_file_header(line)
+    elif record_type == "licence":
+        line_errors = validate_licence_transaction_header(data_identifier, line)
+    elif record_type == "trader":
+        line_errors = validate_permitted_trader(line)
+    elif record_type == "country":
+        line_errors = validate_country(line)
+    elif record_type == "foreignTrader":
+        line_errors = validate_foreign_trader(line)
+    elif record_type == "restrictions":
+        line = validate_restrictions(line)
+    elif record_type == "line":
+        line_errors = validate_licence_product_line(line)
+    elif record_type == "end":
+        line_errors = validate_end_line(line)
+    elif record_type == "fileTrailer":
+        line_errors = validate_file_trailer(line)
+    else:
+        line_errors.append(f"Invalid record type {record_type}")
+
+    return line_errors

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -15,7 +15,9 @@ from mail.libraries.edifact_validator import (
 
 
 class EdifactValidationError(Exception):
-    pass
+    def __init__(self, message, errors):
+        super().__init__(message)
+        self.errors = errors
 
 
 def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
@@ -155,12 +157,19 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
     if errors:
         logging.error(f"File content not as per specification, {errors}")
         logging.info(f"Generated file content: {edifact_file}")
-        raise EdifactValidationError
+        raise EdifactValidationError(f"Errors found in the Edifact file - {edifact_file}", errors=errors)
 
     logging.debug(f"Generated file content: {edifact_file}")
 
     return edifact_file
 
+
+def process_edifact_line(line, line_no):
+    """Tries to validate a line before adding it to the EDIFACT file.
+    If the validation fails, skips the line so that we can process the
+    rest of the licenses.
+    """
+    pass
 
 def get_transaction_reference(licence_reference: str) -> str:
     licence_reference = licence_reference.split("/", 1)[1]


### PR DESCRIPTION
ATM, the EDIFACT is generated from licenses in batches. If there are any errors in any of the licenses, the whole batch fails. This landed us into some issues lately and we had to work around this with a [bit of a hack](https://github.com/uktrade/lite-hmrc/pull/85).

The hack was put in because the code as it currently stands is not amenable to processing licenses one by one. This PR has some ideas that I was working on (before I gave up and put in the hack).