### PR TITLE
Return anonymous user object from hawk auth

### DIFF
--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -22,7 +22,7 @@ class HawkOnlyAuthentication(authentication.BaseAuthentication):
             logging.warning(f"Failed HAWK authentication {e}")
             raise e
 
-        return AnonymousUser, hawk_receiver
+        return AnonymousUser(), hawk_receiver
 
 
 def _authenticate(request):


### PR DESCRIPTION
This was incorrectly returning the class whereas a user object is expected