### PR TITLE
Update logging calls from stack_info to exc_info

### DIFF
--- a/mail/libraries/helpers.py
+++ b/mail/libraries/helpers.py
@@ -157,7 +157,7 @@ def convert_source_to_sender(source) -> str:
 def process_attachment(attachment):
     if len(attachment) != 2:
         logger.error(
-            "Length of attachment is incorrect: attachment=%s", attachment, stack_info=True,
+            "Length of attachment is incorrect: attachment=%s", attachment, exc_info=True,
         )
 
         return "", ""

--- a/mail/models.py
+++ b/mail/models.py
@@ -64,7 +64,7 @@ class Mail(models.Model):
                 self,
                 self.edi_data,
                 self.edi_filename,
-                stack_info=True,
+                exc_info=True,
             )
 
         super(Mail, self).save(*args, **kwargs)

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -151,7 +151,7 @@ def build_lite_payload(lite_usage_data: UsageData):
     payload = build_json_payload_from_data_blocks(data)
     if not payload["licences"]:
         logger.error(
-            "Licences is blank in payload for %s", lite_usage_data, stack_info=True,
+            "Licences is blank in payload for %s", lite_usage_data, exc_info=True,
         )
     payload["usage_data_id"] = str(lite_usage_data.id)
     lite_usage_data.lite_payload = payload


### PR DESCRIPTION
This is due to the fact that sentry doesn't display the stack trace when just using stack_info but will always show a trace (even without an exception) if you set exc_info