### PR TITLE
Strip territory code from Foreign trader address

### DIFF
--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -121,7 +121,7 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
                     trader.get("address").get("line_4", ""),
                     trader.get("address").get("line_5", ""),
                     trader.get("address").get("postcode", ""),
-                    trader.get("address").get("country").get("id"),
+                    get_country_id(trader.get("address").get("country")),
                 )
             line_no += 1
             edifact_file += "\n{}\\restrictions\\{}".format(line_no, "Provisos may apply please see licence")


### PR DESCRIPTION
## Change description

HMRC only allows 2-char country codes and territory codes are longer
than that. If any country is a territory then we strip the territory
code and use the country for that territory. This was missed for
foreign trader address