### PR TITLE
Stop dummy email from being created

### DIFF
--- a/mail/libraries/data_processors.py
+++ b/mail/libraries/data_processors.py
@@ -37,7 +37,7 @@ def serialize_email_message(dto: EmailMessageDto) -> Mail or None:
     logging.info(f"Extract type is identified as {extract_type.upper()}")
 
     instance = get_mail_instance(extract_type, dto.run_number)
-    if not instance and extract_type in [ExtractTypeEnum.USAGE_REPLY]:
+    if not instance and extract_type in [ExtractTypeEnum.USAGE_REPLY, ExtractTypeEnum.LICENCE_REPLY]:
         return
 
     partial = True if instance else False

--- a/mail/tests/test_retreive_and_process_multiple_emails.py
+++ b/mail/tests/test_retreive_and_process_multiple_emails.py
@@ -63,7 +63,7 @@ class MultipleEmailRetrievalTests(LiteHMRCTestClient):
 
         serialize_email_message(self.dto_3)
 
-        self.assertEqual(mail_count, Mail.objects.count() - 1)
+        self.assertEqual(mail_count, Mail.objects.count())
         self.assertEqual(licence_data_count, LicenceData.objects.count())
 
     @tag("sequencing")


### PR DESCRIPTION
Stops attempting to create/update mail message if an instance isn't returned for licence reply type