### PR TITLE
ICMSLST-1467 Use Django's mail backend for SMTP connections

### DIFF
--- a/mail/libraries/mailbox_service.py
+++ b/mail/libraries/mailbox_service.py
@@ -1,7 +1,5 @@
 import logging
-from email.message import Message
 from poplib import POP3_SSL, error_proto
-from smtplib import SMTP
 from typing import Callable, Iterator, List, Tuple
 
 from django.conf import settings
@@ -10,10 +8,6 @@ from mail.enums import MailReadStatuses
 from mail.libraries.email_message_dto import EmailMessageDto
 from mail.libraries.helpers import to_mail_message_dto
 from mail.models import Mail, MailboxConfig, MailReadStatus
-
-
-def send_email(smtp_connection: SMTP, message: Message):
-    smtp_connection.send_message(message)
 
 
 def get_message_id(pop3_connection, listing_msg):

--- a/mail/libraries/routing_controller.py
+++ b/mail/libraries/routing_controller.py
@@ -21,7 +21,7 @@ from mail.libraries.helpers import (
     select_email_for_sending,
     sort_dtos_by_date,
 )
-from mail.libraries.mailbox_service import get_message_iterator, send_email
+from mail.libraries.mailbox_service import get_message_iterator
 from mail.models import Mail
 from mail.servers import MailServer
 
@@ -165,9 +165,9 @@ def update_mail(mail: Mail, mail_dto: EmailMessageDto):
 
 def send(server: MailServer, email_message_dto: EmailMessageDto):
     logger.info("Preparing to send email")
-    smtp_connection = server.connect_to_smtp()
-    send_email(smtp_connection, build_email_message(email_message_dto))
-    server.quit_smtp_connection()
+    message = build_email_message(email_message_dto)
+
+    return server.send_message(message)
 
 
 def _collect_and_send(mail: Mail):

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -16,7 +16,6 @@ from mail.enums import ReceptionStatusEnum
 from mail.libraries.builders import build_licence_data_mail
 from mail.libraries.data_processors import build_request_mail_message_dto
 from mail.libraries.lite_to_edifact_converter import EdifactValidationError
-from mail.libraries.mailbox_service import send_email
 from mail.libraries.routing_controller import check_and_route_emails, send, update_mail
 from mail.libraries.usage_data_decomposition import build_json_payload_from_data_blocks, split_edi_data_by_id
 from mail.models import LicenceIdMapping, LicencePayload, Mail, UsageData
@@ -254,9 +253,8 @@ def notify_users_of_rejected_mail(mail_id, mail_response_date):
         multipart_msg.attach(body)
 
         server = MailServer()
-        smtp_connection = server.connect_to_smtp()
-        send_email(smtp_connection, multipart_msg)
-        server.quit_smtp_connection()
+        server.send_message(multipart_msg)
+
     except Exception as exc:  # noqa
         error_message = (
             f"An unexpected error occurred when notifying users of rejected Mail "

--- a/mail/tests/test_end_to_end.py
+++ b/mail/tests/test_end_to_end.py
@@ -2,11 +2,14 @@ from urllib.parse import quote
 
 import requests
 from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 
 from mail.tests.libraries.client import LiteHMRCTestClient
 
 
+# Force Django to send email so we can check Mailhog.
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend")
 class EndToEndTests(LiteHMRCTestClient):
     def clear_stmp_mailbox(self):
         response = requests.get(f"{settings.MAILHOG_URL}/api/v2/messages")
@@ -40,7 +43,7 @@ class EndToEndTests(LiteHMRCTestClient):
 7\line\1\\\\\Sporting shotgun\Q\\030\\10\\\\\\
 8\end\licence\7
 9\fileTrailer\1"""
-        assert body == expected_mail_body  # nosec
+        self.assertEqual(body, expected_mail_body)  # nosec
         encoded_reference_code = quote("GBSIEL/2020/0000001/P", safe="")
         response = self.client.get(f"{reverse('mail:licence')}?id={encoded_reference_code}")
-        assert response.json()["status"] == "reply_pending"  # nosec
+        self.assertEqual(response.json()["status"], "reply_pending")  # nosec

--- a/mail/tests/test_mail_service.py
+++ b/mail/tests/test_mail_service.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from django.test import SimpleTestCase
 from parameterized import parameterized
 
-from mail.libraries.mailbox_service import get_message_iterator, read_last_message, read_last_three_emails
+from mail.libraries.mailbox_service import read_last_message, read_last_three_emails
 from mail.servers import MailServer
 from mail.tests.libraries.client import LiteHMRCTestClient
 


### PR DESCRIPTION
Instead of having the MailServer class handle opening and closing SMTP
connection, this change uses the Django mail backend stuff for sending
messages. This requires passing an instance of EmailMessage to the
send function, which wraps a MIMEMultipart message.

The tests were updated because Django always adds headers for the
sending date and a random message ID. For now the tests still use an
SMTP server (MailHog) to send a message and check what sent, but this
will be removed in the future.

N.B. I have preserved the behaviour where we end up with both
`Content-Transfer-Encoding: base64` and `Content-Transfer-Encoding: 7bit`
as headers, with the payload as plain text. But we should fix this.