### PR TITLE
Skip reporting usage data when there are no licences

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -194,3 +194,13 @@ class MailReadStatuses:
     UNPROCESSABLE = "UNPROCESSABLE"
 
     choices = [(READ, "Read"), (UNREAD, "Unread"), (UNPROCESSABLE, "Unprocessable")]
+
+
+class LicenceStatusEnum:
+    OPEN = "open"
+    EXHAUST = "exhaust"
+    SURRENDER = "surrender"
+    EXPIRE = "expire"
+    CANCEL = "cancel"
+
+    choices = [(OPEN, "open"), (EXHAUST, "exhaust"), (SURRENDER, "surrender"), (EXPIRE, "expire"), (CANCEL, "cancel")]

--- a/mail/libraries/helpers.py
+++ b/mail/libraries/helpers.py
@@ -9,7 +9,7 @@ from email.message import Message
 from email.parser import Parser
 from json.decoder import JSONDecodeError
 
-from mail.enums import SourceEnum, ExtractTypeEnum, UnitMapping, ReceptionStatusEnum
+from mail.enums import SourceEnum, ExtractTypeEnum, UnitMapping, ReceptionStatusEnum, LicenceStatusEnum
 from mail.libraries.email_message_dto import EmailMessageDto, HmrcEmailMessageDto
 from mail.models import LicenceData, UsageData, Mail, GoodIdMapping, LicenceIdMapping
 from mail import serializers
@@ -320,17 +320,17 @@ def get_licence_id(licence_reference) -> str or None:
         return
 
 
-def get_action(reference) -> str:
+def get_licence_status(reference) -> str:
     if reference == "O":
-        return "open"
+        return LicenceStatusEnum.OPEN
     elif reference == "E":
-        return "exhaust"
+        return LicenceStatusEnum.EXHAUST
     elif reference == "S":
-        return "surrender"
+        return LicenceStatusEnum.SURRENDER
     elif reference == "D":
-        return "expire"
+        return LicenceStatusEnum.EXPIRE
     elif reference == "C":
-        return "cancel"
+        return LicenceStatusEnum.CANCEL
 
 
 def get_country_id(country):

--- a/mail/libraries/usage_data_decomposition.py
+++ b/mail/libraries/usage_data_decomposition.py
@@ -1,5 +1,5 @@
 from mail.enums import SourceEnum
-from mail.libraries.helpers import get_good_id, get_licence_id, get_action
+from mail.libraries.helpers import get_good_id, get_licence_id, get_licence_status
 from mail.models import LicenceIdMapping, TransactionMapping, UsageData
 
 
@@ -95,9 +95,11 @@ def build_json_payload_from_data_blocks(data_blocks: list) -> dict:
             line_array = line.split("\\")
             if "licenceUsage" in line and "end" not in line:
                 licence_reference = line_array[3]
-                action = line_array[4]
-                licence_payload["action"] = get_action(action)
-                if not action == "O" and len(line_array) >= 6:
+                licence_status_code = line_array[4]
+                licence_payload["action"] = get_licence_status(licence_status_code)
+
+                # completion date is only include when licence is complete (i.e., not Open)
+                if licence_status_code != "O" and len(line_array) >= 6:
                     licence_payload["completion_date"] = line_array[5]
                 licence_payload["id"] = get_licence_id(licence_reference)
 

--- a/mail/tests/test_helpers.py
+++ b/mail/tests/test_helpers.py
@@ -11,7 +11,7 @@ from mail.libraries.helpers import (
     new_hmrc_run_number,
     get_run_number,
     map_unit,
-    get_action,
+    get_licence_status,
     process_attachment,
     get_country_id,
 )
@@ -118,7 +118,7 @@ class HelpersTests(LiteHMRCTestClient):
     @parameterized.expand([("O", "open"), ("E", "exhaust"), ("D", "expire"), ("S", "surrender"), ("C", "cancel")])
     @tag("1917", "action-ref")
     def test_action_reference_for_usage(self, reference, action):
-        self.assertEqual(get_action(reference), action)
+        self.assertEqual(get_licence_status(reference), action)
 
     @parameterized.expand(
         [

--- a/mail/tests/test_usage_data_decompostion.py
+++ b/mail/tests/test_usage_data_decompostion.py
@@ -399,3 +399,48 @@ class FileDeconstruction(LiteHMRCTestClient):
             print(t.__dict__)
 
         self.assertEqual(TransactionMapping.objects.count(), 2)
+
+    def test_lite_usage_only_open_licences_are_processed(self):
+        usage_data_from_hmrc = [
+            [
+                "licenceUsage\\LU05234/00318\\insert\\GBSIEL/2021/0000088/P\\C\\20210218",
+                "line\1\\3\\0\\",
+                "end\\line\\2",
+                "line\\2\12\\0\\",
+                "end\\line\\2",
+                "end\\licenceUsage\\6",
+            ],
+            [
+                "licenceUsage\\LU05235/00318\\insert\\GBSIEL/2021/0000090/P\\E\\20210821",
+                "line\1\\3\\0\\",
+                "end\\line\\2",
+                "line\\2\12\\0\\",
+                "end\\line\\2",
+                "line\\3\10\\0\\",
+                "end\\line\\3",
+                "end\\licenceUsage\\8",
+            ],
+        ]
+
+        lite_payload = build_json_payload_from_data_blocks(usage_data_from_hmrc)
+        self.assertEqual(len(lite_payload["licences"]), 0)
+
+        usage_data_from_hmrc += [
+            [
+                "licenceUsage\\LU05233/00180\\insert\\GBSIEL/2021/0000088/P\\O\\",
+                "line\\1\\3\\0\\",
+                "usage\\O\\9GB000004988000-4750437112345\\H\\20220218\\3\\0\\\\GB861460724000\\\\\\\\",
+                "end\\line\\3",
+                "line\\2\\12\\0\\",
+            ],
+            [
+                "licenceUsage\\LU05258/00180\\insert\\SIE22-0000008\\O\\",
+                "line\\1\\3\\0\\",
+                "usage\\O\\9GB000004988000-4750437112345\\H\\20220218\\3\\0\\\\GB861460724000\\\\\\\\",
+                "end\\line\\3",
+                "line\\2\\12\\0\\",
+            ],
+        ]
+
+        lite_payload = build_json_payload_from_data_blocks(usage_data_from_hmrc)
+        self.assertEqual(len(lite_payload["licences"]), 2)


### PR DESCRIPTION
## Change description

HMRC sends us usage data when a licence is used but when the licence is
completed i.e., all the allowed quantity of all products on that licence
are used then we get another usage data transaction with licence status
as cancelled. Currently we skip these transactions hence the licence count
in the payload comes up as 0 but we are trying to report this to LITE.

Since the licences are empty, LITE considers this as an error and throws
an exception. This is not an error and we can skip reporting in this case.