### PR TITLE
LTD-1921: Make edi_filename and edi_data non-nullable

### DIFF
--- a/mail/models.py
+++ b/mail/models.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import timedelta
 from typing import List
 
-from django.db import models
+from django.db import models, IntegrityError
 from django.utils import timezone
 from jsonfield import JSONField
 from model_utils.models import TimeStampedModel
@@ -66,6 +66,7 @@ class Mail(models.Model):
                 self.edi_filename,
                 exc_info=True,
             )
+            raise IntegrityError("The field edi_filename or edi_data is empty which is not valid")
 
         super(Mail, self).save(*args, **kwargs)
 

--- a/mail/tests/test_combining_responses.py
+++ b/mail/tests/test_combining_responses.py
@@ -75,7 +75,7 @@ class CombiningUsageDataReplies(LiteHMRCTestClient):
             "7\\fileTrailer\\2\\1\\0"
         )
 
-        mail = Mail.objects.create(edi_data=edi_data, response_data=spire_response)
+        mail = Mail.objects.create(edi_filename="filename", edi_data=edi_data, response_data=spire_response)
         usage_data = UsageData.objects.create(
             lite_response=lite_response, spire_run_number=12345, hmrc_run_number=54321, mail=mail
         )

--- a/mail/tests/test_data_processors.py
+++ b/mail/tests/test_data_processors.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from django.db import IntegrityError
 
 from django.conf import settings
 from django.test import tag
@@ -41,6 +42,10 @@ class TestDataProcessors(LiteHMRCTestClient):
             spire_run_number=self.source_run_number,
             hmrc_run_number=self.hmrc_run_number,
         )
+
+    def test_mail_create_fails_with_empty_edi_values(self):
+        with self.assertRaises(IntegrityError):
+            Mail.objects.create()
 
     def test_mail_data_serialized_successfully(self):
         email_message_dto = EmailMessageDto(

--- a/mail/tests/test_send_licence_usage_figures_to_lite_api.py
+++ b/mail/tests/test_send_licence_usage_figures_to_lite_api.py
@@ -40,6 +40,7 @@ class UpdateUsagesTaskTests(LiteHMRCTestClient):
             lite_id="80a3d9b2-09a9-4e86-840f-236d186e5b0c", reference="GBSIEL/2020/0000009/P"
         )
         self.mail = Mail.objects.create(
+            edi_filename="usage_data",
             edi_data=(
                 "1\\fileHeader\\CHIEF\\SPIRE\\usageData\\201901130300\\49543\\\n"
                 "2\\licenceUsage\\LU04148/00001\\insert\\GBSIEL/2020/0000008/P\\O\\\n"
@@ -53,7 +54,7 @@ class UpdateUsagesTaskTests(LiteHMRCTestClient):
                 "10\\end\\line\\3\n"
                 "11\\end\\licenceUsage\\5\n"
                 "12\\fileTrailer\\2"
-            )
+            ),
         )
         self.usage_data = UsageData.objects.create(
             id="1e5a4fd0-e581-4efd-9770-ac68e04852d2",
@@ -197,6 +198,7 @@ class UpdateUsagesTaskTests(LiteHMRCTestClient):
         ]
 
         mail = Mail.objects.create(
+            edi_filename="usage_data",
             edi_data=(
                 "1\\fileHeader\\CHIEF\\SPIRE\\usageData\\201901130300\\49543\\\n"
                 "2\\licenceUsage\\LU04148/00001\\insert\\GBSIEL/2020/0000025/P\\O\\\n"
@@ -219,7 +221,7 @@ class UpdateUsagesTaskTests(LiteHMRCTestClient):
                 "19\\end\\line\\2\n"
                 "20\\end\\licenceUsage\\8\n"
                 "21\\fileTrailer\\2"
-            )
+            ),
         )
         usage_data = UsageData.objects.create(
             mail=mail,

--- a/mail/tests/test_send_lite_licence_updates_task.py
+++ b/mail/tests/test_send_lite_licence_updates_task.py
@@ -11,11 +11,15 @@ from mail.libraries.lite_to_edifact_converter import EdifactValidationError
 
 @override_settings(BACKGROUND_TASK_ENABLED=False)  # Disable task from being run on app initialization
 class TaskTests(LiteHMRCTestClient):
+    def setUp(self):
+        self.mail = Mail.objects.create(edi_filename="filename", edi_data="1\\fileHeader\\CHIEF\\SPIRE\\")
+        super().setUp()
+
     @tag("missed-timing")
     @mock.patch("mail.tasks.send")
     def test_pending(self, send):
-        mail = Mail(status=ReceptionStatusEnum.PENDING)
-        mail.save()
+        self.mailstatus = ReceptionStatusEnum.PENDING
+        self.mail.save()
         send.return_value = None
         send_licence_data_to_hmrc.now()
         self.assertEqual(LicencePayload.objects.filter(is_processed=True).count(), 0)
@@ -23,8 +27,8 @@ class TaskTests(LiteHMRCTestClient):
     @tag("missed-timing")
     @mock.patch("mail.tasks.send")
     def test_reply_pending(self, send):
-        mail = Mail(status=ReceptionStatusEnum.REPLY_PENDING)
-        mail.save()
+        self.mail.status = ReceptionStatusEnum.REPLY_PENDING
+        self.mail.save()
         send.return_value = None
         send_licence_data_to_hmrc.now()
         self.assertEqual(LicencePayload.objects.filter(is_processed=True).count(), 0)
@@ -32,8 +36,8 @@ class TaskTests(LiteHMRCTestClient):
     @tag("missed-timing")
     @mock.patch("mail.tasks.send")
     def test_reply_received(self, send):
-        mail = Mail(status=ReceptionStatusEnum.REPLY_RECEIVED)
-        mail.save()
+        self.mail.status = ReceptionStatusEnum.REPLY_RECEIVED
+        self.mail.save()
         send.return_value = None
         send_licence_data_to_hmrc.now()
         self.assertEqual(LicencePayload.objects.filter(is_processed=True).count(), 0)
@@ -41,8 +45,9 @@ class TaskTests(LiteHMRCTestClient):
     @tag("missed-timing", "end-to-end")
     @mock.patch("mail.tasks.send")
     def test_reply_sent_rejected(self, send):
-        mail = Mail(status=ReceptionStatusEnum.REPLY_SENT, response_data="rejected")
-        mail.save()
+        self.mail.status = "reply_sent"
+        self.mail.response_data = "rejected"
+        self.mail.save()
         send.return_value = None
         send_licence_data_to_hmrc.now()
         self.assertEqual(LicencePayload.objects.filter(is_processed=True).count(), 0)
@@ -50,8 +55,9 @@ class TaskTests(LiteHMRCTestClient):
     @tag("missed-timing")
     @mock.patch("mail.tasks.send")
     def test_reply_sent_accepted(self, send):
-        mail = Mail(status=ReceptionStatusEnum.REPLY_SENT, response_data="accepted")
-        mail.save()
+        self.mail.status = ReceptionStatusEnum.REPLY_SENT
+        self.mail.response_data = "accepted"
+        self.mail.save()
         send.return_value = None
         send_licence_data_to_hmrc.now()
         self.assertEqual(LicencePayload.objects.filter(is_processed=True).count(), 1)
@@ -60,4 +66,6 @@ class TaskTests(LiteHMRCTestClient):
     def test_exception(self, validator):
         validator.side_effect = EdifactValidationError()
         with self.assertRaises(EdifactValidationError):
+            self.mail.status = ReceptionStatusEnum.REPLY_SENT
+            self.mail.save()
             send_licence_data_to_hmrc.now()

--- a/mail/tests/test_usage_data_decompostion.py
+++ b/mail/tests/test_usage_data_decompostion.py
@@ -387,13 +387,12 @@ class FileDeconstruction(LiteHMRCTestClient):
 
     @tag("create-transaction-mapping")
     def test_create_transaction_mapping_for_lite_licences(self):
+        mail = Mail.objects.create(edi_filename="filename", edi_data="1\\fileHeader\\CHIEF\\SPIRE\\")
         usage_data = self.licence_usage_file_body.decode("utf-8")
         LicenceIdMapping.objects.create(
             lite_id="00000000-0000-0000-0000-000000000001", reference="GBSIEL/2020/0000002/P"
         )
-        split_edi_data_by_id(
-            usage_data, UsageData.objects.create(mail=Mail.objects.create(), spire_run_number=1, hmrc_run_number=1)
-        )
+        split_edi_data_by_id(usage_data, UsageData.objects.create(mail=mail, spire_run_number=1, hmrc_run_number=1))
 
         for t in TransactionMapping.objects.all():
             print(t.__dict__)


### PR DESCRIPTION
## Change description

There is no valid case where these fields can be empty so check explicitly and fail if either of these fields are empty.
Update tests.