### PR TITLE
ICMSLST-1423 Refactor line number logic in CHIEF message builder

### DIFF
--- a/mail/libraries/chiefprotocol.py
+++ b/mail/libraries/chiefprotocol.py
@@ -1,0 +1,57 @@
+# The CHIEF message protocol(s). "TIS" means technical interface specification.
+# DES235: TIS LINE FILE DIALOGUE AND SYNTAX
+# DES236: TIS – Licence Maintenance and Usage
+#
+# TIS spec jargon:
+# - M: mandatory (required)
+# - O: optional
+# - C: conditional
+# - A: absent (must not be present)
+
+
+import typing
+
+
+def resolve_line_numbers(lines: typing.Sequence[tuple]) -> list:
+    """Add line numbers for a CHIEF message.
+
+    For "end" lines, we keep track of the number of lines since the matching
+    opening line type, and add that number to the end of the line.
+    """
+    starts = {}
+    result = []
+
+    for lineno, line in enumerate(lines, start=1):
+        line_type = line[0]
+        # Track the most recent line number for each line type.
+        starts[line_type] = lineno
+
+        if line_type == "end":
+            # End lines are like ("end", <start-type>). Find the number of
+            # lines since the <start-type> line, add that to the end line
+            # like ("end", <start-type>, <distance>).
+            start_type = line[1]
+            distance = (lineno - starts[start_type]) + 1
+            line += (distance,)
+
+        # Prepend every line with the line number.
+        line = (lineno,) + line
+        result.append(line)
+
+    return result
+
+
+def format_line(line: tuple) -> str:
+    """Format a line, with `None` values as the empty string."""
+    field_sep = "\\"  # A single back-slash character.
+
+    return field_sep.join("" if v is None else str(v) for v in line)
+
+
+def format_lines(lines: typing.Sequence[tuple]) -> str:
+    """Format the sequence of line tuples as 1 complete string."""
+    lines = resolve_line_numbers(lines)
+    formatted_lines = [format_line(line) for line in lines]
+    line_sep = "\n"
+
+    return line_sep.join(formatted_lines) + line_sep

--- a/mail/tests/libraries/test_chiefprotocol.py
+++ b/mail/tests/libraries/test_chiefprotocol.py
@@ -1,0 +1,112 @@
+import unittest
+
+from mail.libraries import chiefprotocol
+
+
+class ResolveLineNumbersTest(unittest.TestCase):
+    def test_add_line_numbers(self):
+        lines = [
+            ("foo",),
+            ("bar",),
+            ("baz",),
+        ]
+        result = chiefprotocol.resolve_line_numbers(lines)
+
+        # Easy: just add numbers in order, starting at 1.
+        expected = [
+            (1, "foo"),
+            (2, "bar"),
+            (3, "baz"),
+        ]
+        self.assertEqual(result, expected)
+
+    def test_end_transaction_1(self):
+        lines = [
+            ("foo",),
+            ("end", "foo"),
+        ]
+        result = chiefprotocol.resolve_line_numbers(lines)
+
+        # An "end" line references a previous type of line, and we append
+        # the number of lines between the start/end (inclusive).
+        expected = [
+            (1, "foo"),
+            (2, "end", "foo", 2),
+        ]
+        self.assertEqual(result, expected)
+
+    def test_end_transaction_2(self):
+        lines = [
+            ("foo",),
+            ("bar",),
+            ("baz",),
+            ("end", "foo"),
+        ]
+        result = chiefprotocol.resolve_line_numbers(lines)
+
+        # There can be multiple lines between the start and "end" lines.
+        expected = [
+            (1, "foo"),
+            (2, "bar"),
+            (3, "baz"),
+            (4, "end", "foo", 4),
+        ]
+        self.assertEqual(result, expected)
+
+    def test_nested_end_transactions(self):
+        lines = [
+            ("foo",),
+            ("bar",),
+            ("baz",),
+            ("end", "bar"),
+            ("bar",),
+            ("baz",),
+            ("end", "bar"),
+            ("end", "foo"),
+        ]
+        result = chiefprotocol.resolve_line_numbers(lines)
+
+        # We have 2 "end" types of "bar".
+        expected = [
+            (1, "foo"),
+            (2, "bar"),
+            (3, "baz"),
+            (4, "end", "bar", 3),
+            (5, "bar"),
+            (6, "baz"),
+            (7, "end", "bar", 3),
+            (8, "end", "foo", 8),
+        ]
+        self.assertEqual(result, expected)
+
+
+class FormatLineTest(unittest.TestCase):
+    def test_format_stringy_type(self):
+        class Stringy:
+            def __str__(self):
+                return "qux!"
+
+        line = ("foo", Stringy(), "bar")
+        result = chiefprotocol.format_line(line)
+
+        self.assertEqual(result, "foo\\qux!\\bar")
+
+    def test_format_none_type(self):
+        line = ("foo", None, "bar")
+        result = chiefprotocol.format_line(line)
+
+        # `None` was formatted as the empty string.
+        self.assertEqual(result, "foo\\\\bar")
+
+
+class FormatLinesTest(unittest.TestCase):
+    def test_format_lines(self):
+        lines = [
+            ("fileHeader",),
+            ("licence",),
+            ("end", "licence"),
+        ]
+        result = chiefprotocol.format_lines(lines)
+
+        expected = "1\\fileHeader\n2\\licence\n3\\end\\licence\\2\n"
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Every line in a CHIEF message starts with the line number, and "end" lines
also have a count of the number of lines since the opening transaction line
(named `distance` in this code change). Moving the logic for line numbering
to the end simplifies the code.

Longer term we should break the logic in `licences_to_edifact(..)` into
smaller pieces, and add flexibility for sending with ILBDOTI (the ICMS
system) and for import licence requests (not just `usage_code = "E"`).