### PR TITLE
LTD: Remove unnecessary mail is pending error as it is not an error

### DIFF
--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -14,7 +14,7 @@ from django.db import transaction
 from django.utils import timezone
 from rest_framework.status import HTTP_207_MULTI_STATUS, HTTP_208_ALREADY_REPORTED
 
-from mail.enums import ReceptionStatusEnum, ReplyStatusEnum
+from mail.enums import ReceptionStatusEnum
 from mail.libraries.builders import build_licence_data_mail
 from mail.libraries.data_processors import build_request_mail_message_dto
 from mail.libraries.mailbox_service import send_email
@@ -205,8 +205,11 @@ def send_licence_data_to_hmrc():
 
     logging.info("Sending LITE licence updates to HMRC")
 
-    if not _is_email_slot_free():
-        logging.info("There is currently an update in progress or an email is in flight")
+    if Mail.objects.exclude(status=ReceptionStatusEnum.REPLY_SENT).count():
+        logging.info(
+            "Currently we are either waiting for a reply or next one is ready to be processed,\n"
+            "so we cannot send this update now and will be picked up in the next cycle"
+        )
         return
 
     try:
@@ -244,31 +247,7 @@ def send_licence_data_to_hmrc():
         return True
 
 
-def _is_email_slot_free() -> bool:
-    pending_mail = _get_pending_mail()
-    if pending_mail:
-        logging.error(f"The following Mail is pending: {pending_mail}")
-        return False
-
-    return True
-
-
-def _get_pending_mail() -> []:
-    return list(Mail.objects.exclude(status=ReceptionStatusEnum.REPLY_SENT).values_list("id", flat=True))
-
-
-def _get_rejected_mail() -> []:
-    return list(
-        Mail.objects.filter(
-            status=ReceptionStatusEnum.REPLY_SENT,
-            response_data__icontains=ReplyStatusEnum.REJECTED,
-        ).values_list("id", flat=True)
-    )
-
-
 # Notify Users of Rejected Mail
-
-
 @background(queue=NOTIFY_USERS_TASK_QUEUE, schedule=0)
 def notify_users_of_rejected_mail(mail_id, mail_response_date):
     """If a rejected email is found, this task notifies users of the rejection"""


### PR DESCRIPTION
## Change description

When send_licence_data_to_hmrc() task runs it checks to see if there is an update
in progress. An update can be either we are waiting for a reply or the next email
is about to be processed (eg new email just got created and check_inbox task about
to process it, in this case it will be in pending state).

Since we have to wait till we completely process an email (i.e, reply_sent state)
we should skip this update when there is an update in progress, this gets picked
up in the next polling cycle.

Currently we are logging an error if an update in progress. This is not an error
and it unnecessarily adds noise to the alerts hence remove this.