### PR TITLE
Fix the PII checker and Black failing pre-commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: (exporter/assets/built/|caseworker/assets/built/)
 repos:
     - repo: https://github.com/psf/black
-      rev: 22.1.0
+      rev: 22.3.0
       hooks:
           - id: black
           # Config for black lives in pyproject.toml
@@ -9,7 +9,7 @@ repos:
       rev: v1.12.1
       hooks:
           - id: blacken-docs
-            additional_dependencies: [black==22.1.0]
+            additional_dependencies: [black==22.3.0]
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.1.0
       hooks:
@@ -34,6 +34,7 @@ repos:
             pass_filenames: true
             require_serial: true
           - id: pii_secret_file_content
+            additional_dependencies: [click==8.0.4]
             files: ''
             language: python
             args: [--exclude=pii-secret-exclude.txt]


### PR DESCRIPTION
Click version 8.1.0 was released recently and it changed some of the
internals. This caused a new clean install of the PII checker tool
to fail with an ImportError exception in a transitive dependency.

For now we can pin the dependency to an older version.

Black released a new version that fixes the use of internals.