### PR TITLE
ICMSLST-1486 Count licences using the CHIEF message

### DIFF
--- a/mail/libraries/chiefprotocol.py
+++ b/mail/libraries/chiefprotocol.py
@@ -55,3 +55,10 @@ def format_lines(lines: typing.Sequence[tuple]) -> str:
     line_sep = "\n"
 
     return line_sep.join(formatted_lines) + line_sep
+
+
+def count_transactions(lines: typing.Sequence[tuple]) -> int:
+    """Count of licence transactions, for use on the `fileTrailer` line."""
+    # A transaction is any line  with "licence" as the first field (ignoring
+    # line numbers).
+    return sum(line[0] == "licence" for line in lines)

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -199,7 +199,7 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
 
     # File trailer includes the number of licences, but +1 for each "update"
     # because this code represents those as "cancel" followed by "insert".
-    num_transactions = licences.count() + licences.filter(action=LicenceActionEnum.UPDATE).count()
+    num_transactions = chiefprotocol.count_transactions(lines)
     file_trailer = ("fileTrailer", num_transactions)
     lines.append(file_trailer)
 

--- a/mail/tests/libraries/test_chiefprotocol.py
+++ b/mail/tests/libraries/test_chiefprotocol.py
@@ -110,3 +110,27 @@ class FormatLinesTest(unittest.TestCase):
 
         expected = "1\\fileHeader\n2\\licence\n3\\end\\licence\\2\n"
         self.assertEqual(result, expected)
+
+
+class CountTransactionsTest(unittest.TestCase):
+    def test_count_zero_licences(self):
+        lines = [
+            ("fileHeader",),
+            ("fileTrailer",),
+        ]
+        result = chiefprotocol.count_transactions(lines)
+
+        self.assertEqual(result, 0)
+
+    def test_count_many_licences(self):
+        lines = [
+            ("fileHeader",),
+            ("licence",),
+            ("end", "licence"),
+            ("licence",),
+            ("end", "licence"),
+            ("fileTrailer",),
+        ]
+        result = chiefprotocol.count_transactions(lines)
+
+        self.assertEqual(result, 2)


### PR DESCRIPTION
Instead of making SQL queries, use the actual count of "licence"
transactions that are present in a CHIEF message (which is what
that trailing count is supposed to be).

The advantage of this is we can untangle some of the database
logic from building the actual CHIEF message.