### PR TITLE
ICMSLST-1541 Use the error text for EdifactValidationError's message

### DIFF
--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -210,7 +210,7 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
     errors = validate_edifact_file(edifact_file)
     if errors:
         logging.error("File content not as per specification, %r", errors)
-        raise EdifactValidationError
+        raise EdifactValidationError(repr(errors))
 
     return edifact_file
 


### PR DESCRIPTION
Including the error text makes it easier to understand what the problem
is when a test breaks with an EdifactValidationError exception. The test
runner prints the exception message, instead of just the exception name.