### PR TITLE
ICMSLST-1541 Add types for CHIEF message lines

### DIFF
--- a/mail/libraries/chieftypes.py
+++ b/mail/libraries/chieftypes.py
@@ -1,0 +1,165 @@
+from dataclasses import dataclass
+from typing import Optional
+
+# These types represent the structure of records in a CHIEF message. A message
+# is one of licenceData, licenceReply, usageData, or usageReply types.
+
+# Every line in a message starts with a line number, and then the record type.
+@dataclass
+class _Record:
+    lineno: Optional[int] = None
+    type_: Optional[str] = None
+
+
+# Every message starts and ends with the file header.
+@dataclass
+class FileHeader(_Record):
+    type_: Optional[str] = "fileHeader"
+    source_system: Optional[str] = None
+    destination_system: Optional[str] = None
+    data_id: Optional[str] = None
+    creation_date_time: Optional[str] = None
+    run_num: Optional[int] = None
+    reset_run_num: Optional[str] = None
+
+
+@dataclass
+class FileTrailer(_Record):
+    type_: Optional[str] = "fileTrailer"
+    transaction_count: Optional[int] = None
+    # The spec also allows a hash_total field, but this implementation
+    # flags that as an error when validating.
+    # hash_total: Optional[str] = None
+
+
+# Several types have a matching "end" line.
+@dataclass
+class End(_Record):
+    type_: Optional[str] = "end"
+    start_record_type: Optional[str] = None
+    record_count: Optional[int] = None
+
+
+# Licence data (request).
+@dataclass
+class Licence(_Record):
+    type_: Optional[str] = "licence"
+    transaction_ref: Optional[str] = None
+    action: Optional[str] = None
+    licence_ref: Optional[str] = None
+    licence_type: Optional[str] = None
+    usage: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+
+
+@dataclass
+class Trader(_Record):
+    type_: Optional[str] = "trader"
+    turn: Optional[str] = None
+    rpa_trader_id: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    name: Optional[str] = None
+    address1: Optional[str] = None
+    address2: Optional[str] = None
+    address3: Optional[str] = None
+    address4: Optional[str] = None
+    address5: Optional[str] = None
+    postcode: Optional[str] = None
+
+
+@dataclass
+class Country(_Record):
+    type_: Optional[str] = "country"
+    code: Optional[str] = None
+    group: Optional[str] = None
+    use: Optional[str] = None
+
+
+@dataclass
+class ForeignTrader(_Record):
+    type_: Optional[str] = "foreignTrader"
+    name: Optional[str] = None
+    address1: Optional[str] = None
+    address2: Optional[str] = None
+    address3: Optional[str] = None
+    address4: Optional[str] = None
+    address5: Optional[str] = None
+    postcode: Optional[str] = None
+    country: Optional[str] = None
+
+
+@dataclass
+class Restrictions(_Record):
+    type_: Optional[str] = "restrictions"
+    text: Optional[str] = None
+
+
+@dataclass
+class LicenceDataLine(_Record):
+    """The `line` data in a licence data (request) message.
+
+    This is not the same as the `line` record in a usage data message.
+    """
+
+    type_: Optional[str] = "line"
+    line_num: Optional[int] = None
+    commodity: Optional[str] = None
+    supplement1: Optional[str] = None
+    supplement2: Optional[str] = None
+    commodity_group: Optional[str] = None
+    goods_description: Optional[str] = None
+    controlled_by: Optional[str] = None
+    currency: Optional[str] = None
+    quantity_unit: Optional[str] = None
+    value_issued: Optional[str] = None
+    quantity_issued: Optional[str] = None
+    sub_period: Optional[str] = None
+    sub_period_quantity: Optional[str] = None
+    sub_period_value: Optional[str] = None
+    afc_rate: Optional[str] = None
+    afc_quantity_unit: Optional[str] = None
+    afc_currency: Optional[str] = None
+
+
+# Licence usage message.
+@dataclass
+class LicenceUsage(_Record):
+    type_: Optional[str] = "usage"
+    transaction_ref: Optional[str] = None
+    action: Optional[str] = None
+    licence_ref: Optional[str] = None
+    licence_status: Optional[str] = None
+    completion_date: Optional[str] = None
+
+
+@dataclass
+class LicenceUsageLine(_Record):
+    """For use in a licence usage message (not a licence transaction)."""
+
+    type_: Optional[str] = "line"
+    line_num: Optional[int] = None
+    quantity_used: Optional[str] = None
+    value_used: Optional[str] = None
+    currency: Optional[str] = None
+
+
+@dataclass
+class Usage(_Record):
+    type_: Optional[str] = "usage"
+    usage_type: Optional[str] = None
+    declaration_urc: Optional[str] = None
+    declaration_part_num: Optional[str] = None
+    control_date: Optional[str] = None
+    quantity_used: Optional[str] = None
+    value_used: Optional[str] = None
+    currency: Optional[str] = None
+    trader_id: Optional[str] = None
+    claim_ref: Optional[str] = None
+    origin_country: Optional[str] = None
+    customs_mic: Optional[str] = None
+    customs_message: Optional[str] = None
+    consignee_name: Optional[str] = None
+    declaration_mrn: Optional[str] = None
+    departure_ics: Optional[str] = None

--- a/mail/tests/libraries/test_chiefprotocol.py
+++ b/mail/tests/libraries/test_chiefprotocol.py
@@ -1,81 +1,75 @@
+import typing
 import unittest
 
 from mail.libraries import chiefprotocol
+from mail.libraries.chieftypes import End, FileHeader, FileTrailer, Licence, LicenceDataLine, _Record
 
 
 class ResolveLineNumbersTest(unittest.TestCase):
     def test_add_line_numbers(self):
         lines = [
-            ("foo",),
-            ("bar",),
-            ("baz",),
+            FileHeader(),
+            FileTrailer(),
         ]
         result = chiefprotocol.resolve_line_numbers(lines)
 
         # Easy: just add numbers in order, starting at 1.
         expected = [
-            (1, "foo"),
-            (2, "bar"),
-            (3, "baz"),
+            FileHeader(lineno=1),
+            FileTrailer(lineno=2),
         ]
         self.assertEqual(result, expected)
 
     def test_end_transaction_1(self):
         lines = [
-            ("foo",),
-            ("end", "foo"),
+            Licence(),
+            End(start_record_type=Licence.type_),
         ]
         result = chiefprotocol.resolve_line_numbers(lines)
 
         # An "end" line references a previous type of line, and we append
         # the number of lines between the start/end (inclusive).
         expected = [
-            (1, "foo"),
-            (2, "end", "foo", 2),
+            Licence(lineno=1, type_="licence"),
+            End(lineno=2, start_record_type="licence", record_count=2),
         ]
         self.assertEqual(result, expected)
 
     def test_end_transaction_2(self):
         lines = [
-            ("foo",),
-            ("bar",),
-            ("baz",),
-            ("end", "foo"),
+            Licence(),
+            LicenceDataLine(),
+            LicenceDataLine(),
+            End(start_record_type=Licence.type_),
         ]
         result = chiefprotocol.resolve_line_numbers(lines)
 
         # There can be multiple lines between the start and "end" lines.
-        expected = [
-            (1, "foo"),
-            (2, "bar"),
-            (3, "baz"),
-            (4, "end", "foo", 4),
-        ]
-        self.assertEqual(result, expected)
+        expected_last_line = End(lineno=4, start_record_type="licence", record_count=4)
+        self.assertEqual(result[-1], expected_last_line)
 
     def test_nested_end_transactions(self):
         lines = [
-            ("foo",),
-            ("bar",),
-            ("baz",),
-            ("end", "bar"),
-            ("bar",),
-            ("baz",),
-            ("end", "bar"),
-            ("end", "foo"),
+            FileHeader(),
+            Licence(),
+            LicenceDataLine(),
+            End(start_record_type=Licence.type_),
+            Licence(),
+            LicenceDataLine(),
+            End(start_record_type=Licence.type_),
+            FileTrailer(),
         ]
         result = chiefprotocol.resolve_line_numbers(lines)
 
-        # We have 2 "end" types of "bar".
         expected = [
-            (1, "foo"),
-            (2, "bar"),
-            (3, "baz"),
-            (4, "end", "bar", 3),
-            (5, "bar"),
-            (6, "baz"),
-            (7, "end", "bar", 3),
-            (8, "end", "foo", 8),
+            FileHeader(lineno=1),
+            Licence(lineno=2),
+            LicenceDataLine(lineno=3),
+            End(lineno=4, start_record_type="licence", record_count=3),
+            Licence(lineno=5),
+            LicenceDataLine(lineno=6),
+            End(lineno=7, start_record_type="licence", record_count=3),
+            FileTrailer(lineno=8),
         ]
         self.assertEqual(result, expected)
 
@@ -86,37 +80,37 @@ class FormatLineTest(unittest.TestCase):
             def __str__(self):
                 return "qux!"
 
-        line = ("foo", Stringy(), "bar")
+        line = _Record(lineno=None, type_=Stringy())
         result = chiefprotocol.format_line(line)
 
-        self.assertEqual(result, "foo\\qux!\\bar")
+        self.assertEqual(result, "\\qux!")
 
     def test_format_none_type(self):
-        line = ("foo", None, "bar")
+        line = _Record(lineno=None, type_=None)
         result = chiefprotocol.format_line(line)
 
         # `None` was formatted as the empty string.
-        self.assertEqual(result, "foo\\\\bar")
+        self.assertEqual(result, "\\")
 
 
 class FormatLinesTest(unittest.TestCase):
     def test_format_lines(self):
         lines = [
-            ("fileHeader",),
-            ("licence",),
-            ("end", "licence"),
+            FileHeader(),
+            Licence(),
+            End(start_record_type=Licence.type_),
         ]
         result = chiefprotocol.format_lines(lines)
 
-        expected = "1\\fileHeader\n2\\licence\n3\\end\\licence\\2\n"
+        expected = "1\\fileHeader\\\\\\\\\\\\\n" "2\\licence\\\\\\\\\\\\\\\n" "3\\end\\licence\\2\n"
         self.assertEqual(result, expected)
 
 
 class CountTransactionsTest(unittest.TestCase):
     def test_count_zero_licences(self):
         lines = [
-            ("fileHeader",),
-            ("fileTrailer",),
+            FileHeader(),
+            FileTrailer(),
         ]
         result = chiefprotocol.count_transactions(lines)
 
@@ -124,12 +118,12 @@ class CountTransactionsTest(unittest.TestCase):
 
     def test_count_many_licences(self):
         lines = [
-            ("fileHeader",),
-            ("licence",),
-            ("end", "licence"),
-            ("licence",),
-            ("end", "licence"),
-            ("fileTrailer",),
+            FileHeader(),
+            Licence(),
+            End(start_record_type=Licence.type_),
+            Licence(),
+            End(start_record_type=Licence.type_),
+            FileTrailer(),
         ]
         result = chiefprotocol.count_transactions(lines)
 

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from parameterized import parameterized
 
 from mail.enums import LicenceActionEnum
+from mail.libraries.chieftypes import Country
 from mail.libraries.lite_to_edifact_converter import (
     EdifactValidationError,
     generate_lines_for_licence,
@@ -192,9 +193,9 @@ class GenerateLinesForLicenceTest(LiteHMRCTestClient):
         lines = list(generate_lines_for_licence(licence))
 
         expected_types = ["licence", "trader", "country", "restrictions", "line", "end"]
-        self.assertEqual([line[0] for line in lines], expected_types)
-        # The country code is the 3rd field.
-        self.assertEqual(lines[2], ("country", None, "G012", "D"))
+        self.assertEqual([line.type_ for line in lines], expected_types)
+        # The country code is the 3rd field, `group`.
+        self.assertEqual(lines[2], Country(code=None, group="G012", use="D"))
 
     def test_open_licence_with_multiple_countries(self):
         data = {
@@ -212,7 +213,7 @@ class GenerateLinesForLicenceTest(LiteHMRCTestClient):
 
         # Note there are 2 country lines.
         expected_types = ["licence", "trader", "country", "country", "restrictions", "line", "end"]
-        self.assertEqual([line[0] for line in lines], expected_types)
-        # The country code is the 2nd field.
-        self.assertEqual(lines[2], ("country", "GB", None, "D"))
-        self.assertEqual(lines[3], ("country", "NI", None, "D"))
+        self.assertEqual([line.type_ for line in lines], expected_types)
+        # The country code is the 2nd field, `code`.
+        self.assertEqual(lines[2], Country(code="GB", group=None, use="D"))
+        self.assertEqual(lines[3], Country(code="NI", group=None, use="D"))


### PR DESCRIPTION
This uses dataclasses to define the line structure, because they support
inheriting field declarations whereas collections.namedtuple does not.
Dataclasses also allow using keyword arguments with the constructor.

The big improvement is we can have a little bit more self-documenting
code with names for the fields, instead of items in tuples with an
order that seems arbitrary but is very significant.

In CHIEF syntax every line starts with the line number and record type,
but for our use it is very useful to leave the line number unknown
until we construct the final message. But if you have one field in a
dataclass as optional, then all fields that follow must also be optional.