### PR TITLE
LTD-2187: Update licence reference extraction to consider new naming scheme

### DIFF
--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -1,3 +1,4 @@
+import re
 import logging
 import textwrap
 
@@ -216,8 +217,14 @@ def licences_to_edifact(licences: QuerySet, run_number: int) -> str:
 
 
 def get_transaction_reference(licence_reference: str) -> str:
-    licence_reference = licence_reference.split("/", 1)[1]
-    return licence_reference.replace("/", "")
+    if licence_reference.startswith("GB"):
+        licence_reference = licence_reference.split("/", 1)[1]
+        return licence_reference.replace("/", "")
+    else:
+        match_first_digit = re.search(r"\d", licence_reference)
+        if not match_first_digit:
+            raise ValueError("Invalid Licence reference")
+        return licence_reference[match_first_digit.start() :].replace("-", "")
 
 
 def sanitize_foreign_trader_address(trader):

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -60,8 +60,18 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
         self.single_siel_licence_payload.refresh_from_db()
         self.assertEqual(self.single_siel_licence_payload.is_processed, True)
 
-    def test_ref(self):
-        self.assertEqual(get_transaction_reference("GBSIEL/2020/0000001/P"), "20200000001P")
+    @parameterized.expand(
+        [
+            ("GBSIEL/2020/0000001/P", "20200000001P"),
+            ("SIE22-0000025-01", "22000002501"),
+        ]
+    )
+    def test_extract_reference(self, licence_reference, expected_reference):
+        self.assertEqual(get_transaction_reference(licence_reference), expected_reference)
+
+    def test_invalid_licence_reference_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            get_transaction_reference("SIE-INVALID-REF")
 
     def test_update_edifact_file(self):
         lp = LicencePayload.objects.get()


### PR DESCRIPTION
## Change description

We have changed the way the Application reference and hence the licence reference
numbers are generated but didn't update lite-hmrc to consider the new naming
scheme because of this when sending licence details with these new names then
the helper function is not able to generate the reference correctly.