### PR TITLE
ICMSLST-1537 Use gunicorn for serving in production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-web: python manage.py migrate && ./manage.py runserver 0.0.0.0:$PORT
+# See gunicorn.conf.py for more configuration.
+web: python manage.py migrate && gunicorn conf.wsgi:application
 worker: python manage.py process_tasks --log-std

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,8 @@
+# Default gunicorn config file. https://docs.gunicorn.org/en/stable/configure.html
+import gunicorn
+
+# Override the `Server: gunicorn/x.y.z` version header in responses.
+gunicorn.SERVER_SOFTWARE = "lite-hmrc"
+
+accesslog = "-"
+errorlog = "-"


### PR DESCRIPTION
Instead of Django's development server, use gunicorn. Default behaviour
reads a configuration from gunicorn.conf.py and binds to 0.0.0.0:$PORT
when $PORT is defined in the environment.

The config overrides the `Server` response header to hide gunicorn's
signature. This is silly, but part of a belt-and-braces approach to
security. However the header is then reset by another proxy. If we ever
deploy the app with a proxy that respects the app `Server` header, it
would show the customised, obscured signature.