### PR TITLE
ICMSLST-1530 Use DRF serializers for validating API requests

### DIFF
--- a/mail/tests/test_serializers.py
+++ b/mail/tests/test_serializers.py
@@ -1,0 +1,139 @@
+from django.test import TestCase
+
+from mail.enums import LicenceTypeEnum
+from mail.serializers import LiteLicenceDataSerializer
+
+
+class LiteLicenceDataSerializerTestCase(TestCase):
+    def test_no_data(self):
+        serializer = LiteLicenceDataSerializer(data={})
+
+        self.assertFalse(serializer.is_valid())
+        expected_errors = {
+            "action": ["This field is required."],
+            "end_date": ["This field is required."],
+            "id": ["This field is required."],
+            "reference": ["This field is required."],
+            "start_date": ["This field is required."],
+            "type": ["This field is required."],
+        }
+        self.assertDictEqual(serializer.errors, expected_errors)
+
+    def test_old_id_required_when_action_is_update(self):
+        data = {
+            "action": "update",
+            "end_date": "1999-12-31",
+            "id": "foo",
+            "reference": "bar",
+            "start_date": "1999-12-31",
+            "type": "baz",
+        }
+        serializer = LiteLicenceDataSerializer(data=data)
+
+        self.assertFalse(serializer.is_valid())
+        expected_errors = {
+            "old_id": ["This field is required."],
+        }
+        self.assertDictEqual(serializer.errors, expected_errors)
+
+    def test_invalid_old_id_when_action_is_update(self):
+        data = {
+            "action": "update",
+            "end_date": "1999-12-31",
+            "id": "foo",
+            # This is a valid UUID-format key, but there is no matching
+            # record in the database.
+            "old_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "reference": "bar",
+            "start_date": "1999-12-31",
+            "type": "baz",
+        }
+        serializer = LiteLicenceDataSerializer(data=data)
+
+        self.assertFalse(serializer.is_valid())
+        expected_errors = {
+            "old_id": ["This licence does not exist in HMRC integration records"],
+        }
+        self.assertDictEqual(serializer.errors, expected_errors)
+
+    def test_required_fields_for_open_or_general_type(self):
+        for type_ in LicenceTypeEnum.OPEN_LICENCES + LicenceTypeEnum.OPEN_GENERAL_LICENCES:
+            with self.subTest(type_=type_):
+                data = {
+                    "action": "insert",
+                    "end_date": "1999-12-31",
+                    "id": "foo",
+                    "reference": "bar",
+                    "start_date": "1999-12-31",
+                    "type": type_,
+                }
+                serializer = LiteLicenceDataSerializer(data=data)
+
+                self.assertFalse(serializer.is_valid())
+
+                expected_errors = {
+                    "countries": ["This field is required."],
+                }
+                self.assertDictEqual(serializer.errors, expected_errors)
+
+    def test_required_fields_for_standard_type(self):
+        for type_ in LicenceTypeEnum.STANDARD_LICENCES:
+            with self.subTest(type_=type_):
+                data = {
+                    "action": "insert",
+                    "end_date": "1999-12-31",
+                    "id": "foo",
+                    "reference": "bar",
+                    "start_date": "1999-12-31",
+                    "type": type_,
+                }
+                serializer = LiteLicenceDataSerializer(data=data)
+
+                self.assertFalse(serializer.is_valid())
+
+                expected_errors = {
+                    "end_user": ["This field is required."],
+                    "goods": ["This field is required."],
+                }
+                self.assertDictEqual(serializer.errors, expected_errors)
+
+    def test_minimum_countries_for_open_type(self):
+        # For open licence types, the request data must include at least 1
+        # country item.
+        data = {
+            "action": "insert",
+            "end_date": "1999-12-31",
+            "id": "foo",
+            "reference": "bar",
+            "start_date": "1999-12-31",
+            "type": LicenceTypeEnum.OPEN_LICENCES[0],
+            "countries": [],
+        }
+        serializer = LiteLicenceDataSerializer(data=data)
+
+        self.assertFalse(serializer.is_valid())
+        expected_errors = {
+            "countries": {
+                "non_field_errors": ["Ensure this field has at least 1 elements."],
+            },
+        }
+        self.assertDictEqual(serializer.errors, expected_errors)
+
+    def test_valid_countries_for_open_type(self):
+        data = {
+            "action": "insert",
+            "end_date": "1999-12-31",
+            "id": "foo",
+            "reference": "bar",
+            "start_date": "1999-12-31",
+            "type": LicenceTypeEnum.OPEN_LICENCES[0],
+            "countries": [
+                {
+                    "id": "GB",
+                    "name": "United Kingdom",
+                }
+            ],
+        }
+        serializer = LiteLicenceDataSerializer(data=data)
+
+        self.assertTrue(serializer.is_valid())

--- a/mail/views.py
+++ b/mail/views.py
@@ -3,13 +3,12 @@ import logging
 from django.http import HttpResponse, JsonResponse
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.status import HTTP_200_OK, HTTP_500_INTERNAL_SERVER_ERROR
 from rest_framework.views import APIView
 
 from conf.authentication import HawkOnlyAuthentication
-from mail.enums import LicenceActionEnum, LicenceTypeEnum, ReceptionStatusEnum
+from mail.enums import LicenceActionEnum, ReceptionStatusEnum
 from mail.models import LicenceData, LicenceIdMapping, LicencePayload, Mail
-from mail.serializers import ForiegnTraderSerializer, GoodSerializer, LiteLicenceDataSerializer, MailSerializer
+from mail.serializers import LiteLicenceDataSerializer, MailSerializer
 from mail.tasks import send_licence_data_to_hmrc
 
 
@@ -17,69 +16,44 @@ class LicenceDataIngestView(APIView):
     authentication_classes = (HawkOnlyAuthentication,)
 
     def post(self, request):
-        errors = []
-
-        licence = request.data.get("licence")
-
-        if not licence:
-            errors.append({"licence": "This field is required."})
-        else:
-            serializer = LiteLicenceDataSerializer(data=licence)
-            if not serializer.is_valid():
-                errors.append({"licence": serializer.errors})
-            else:
-                if licence.get("action") == LicenceActionEnum.UPDATE:
-                    licence["old_reference"] = LicenceIdMapping.objects.get(lite_id=licence["old_id"]).reference
-                else:
-                    licence.pop("old_id", None)
-
-            if licence.get("type") in LicenceTypeEnum.OPEN_LICENCES + LicenceTypeEnum.OPEN_GENERAL_LICENCES:
-                countries = licence.get("countries")
-                if not countries:
-                    errors.append({"countries": "This field is required."})
-
-            if licence.get("type") in LicenceTypeEnum.STANDARD_LICENCES:
-                end_user = licence.get("end_user")
-                if not end_user:
-                    errors.append({"end_user": "This field is required."})
-                else:
-                    serializer = ForiegnTraderSerializer(data=end_user)
-                    if not serializer.is_valid():
-                        errors.append({"end_user": serializer.errors})
-
-                goods = licence.get("goods")
-                if not goods:
-                    errors.append({"goods": "This field is required."})
-                else:
-                    for good in licence.get("goods"):
-                        serializer = GoodSerializer(data=good)
-                        if not serializer.is_valid():
-                            errors.append({"goods": serializer.errors})
-
-        if errors:
+        try:
+            data = request.data["licence"]
+        except KeyError:
+            errors = [{"licence": "This field is required."}]
             return JsonResponse(status=status.HTTP_400_BAD_REQUEST, data={"errors": errors})
         else:
-            licence, created = LicencePayload.objects.get_or_create(
-                lite_id=licence["id"],
-                reference=licence["reference"],
-                action=licence["action"],
-                old_lite_id=licence.get("old_id"),
-                old_reference=licence.get("old_reference"),
-                defaults=dict(
-                    lite_id=licence["id"],
-                    reference=licence["reference"],
-                    data=licence,
-                    old_lite_id=licence.get("old_id"),
-                    old_reference=licence.get("old_reference"),
-                ),
-            )
+            serializer = LiteLicenceDataSerializer(data=data)
 
-            logging.info(f"Created LicencePayload [{licence.lite_id}, {licence.reference}, {licence.action}]")
+        if not serializer.is_valid():
+            errors = [{"licence": serializer.errors}]
+            return JsonResponse(status=status.HTTP_400_BAD_REQUEST, data={"errors": errors})
 
-            return JsonResponse(
-                status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
-                data={"licence": licence.data},
-            )
+        if data["action"] == LicenceActionEnum.UPDATE:
+            data["old_reference"] = LicenceIdMapping.objects.get(lite_id=data["old_id"]).reference
+        else:
+            data.pop("old_id", None)
+
+        licence, created = LicencePayload.objects.get_or_create(
+            lite_id=data["id"],
+            reference=data["reference"],
+            action=data["action"],
+            old_lite_id=data.get("old_id"),
+            old_reference=data.get("old_reference"),
+            defaults=dict(
+                lite_id=data["id"],
+                reference=data["reference"],
+                data=data,
+                old_lite_id=data.get("old_id"),
+                old_reference=data.get("old_reference"),
+            ),
+        )
+
+        logging.info("Created LicencePayload [%s, %s, %s]", licence.lite_id, licence.reference, licence.action)
+
+        return JsonResponse(
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+            data={"licence": licence.data},
+        )
 
 
 class SendLicenceUpdatesToHmrc(APIView):
@@ -89,9 +63,9 @@ class SendLicenceUpdatesToHmrc(APIView):
         """
         success = send_licence_data_to_hmrc.now()
         if success:
-            return HttpResponse(status=HTTP_200_OK)
+            return HttpResponse(status=status.HTTP_200_OK)
         else:
-            return HttpResponse(status=HTTP_500_INTERNAL_SERVER_ERROR)
+            return HttpResponse(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class SetAllToReplySent(APIView):
@@ -101,7 +75,7 @@ class SetAllToReplySent(APIView):
 
     def get(self, _):
         Mail.objects.all().update(status=ReceptionStatusEnum.REPLY_SENT)
-        return HttpResponse(status=HTTP_200_OK)
+        return HttpResponse(status=status.HTTP_200_OK)
 
 
 class Licence(APIView):
@@ -114,10 +88,10 @@ class Licence(APIView):
         matching_licences = LicenceData.objects.filter(licence_ids__contains=license_ref)
         matching_licences_count = matching_licences.count()
         if matching_licences_count > 1:
-            logging.warn(f"Too many matches for licence '{license_ref}'")
+            logging.warn("Too many matches for licence '%s'", license_ref)
             return Response(status=status.HTTP_400_BAD_REQUEST)
         elif matching_licences_count == 0:
-            logging.warn(f"No matches for licence '{license_ref}'")
+            logging.warn("No matches for licence '%s'", license_ref)
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         # Return single matching licence


### PR DESCRIPTION
Move the logic for validating request data from the "/mail/update/" view
handler to the Django Rest Framework serializer class. Because some of
the fields are only required depending on the value of the "type" field,
the serializer fields are declared as optional, and then made required
(if necessary).