### PR TITLE
ICMSLST-1547 Backport Django's Choices/enum type for use with enums

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -1,152 +1,199 @@
-LITE_HMRC_LICENCE_TYPE_MAPPING = {
-    "siel": "SIE",
-    "sicl": "SIE",
-    "sitl": "SIE",
-    "oiel": "OIE",
-    "ogel": "OGE",
-    "ogcl": "OGE",
-    "ogtl": "OGE",
-}
+import enum
+from types import DynamicClassAttribute
+
+from django.utils.decorators import classproperty
+from django.utils.functional import Promise
 
 
-class LicenceActionEnum:
+# Backported from Django 4.x
+# https://github.com/django/django/blob/9c19aff7c/django/db/models/enums.py  /PS-IGNORE
+class ChoicesMeta(enum.EnumMeta):
+    """A metaclass for creating a enum choices."""
+
+    def __new__(metacls, classname, bases, classdict, **kwds):
+        labels = []
+        for key in classdict._member_names:
+            value = classdict[key]
+            if isinstance(value, (list, tuple)) and len(value) > 1 and isinstance(value[-1], (Promise, str)):
+                *value, label = value
+                value = tuple(value)
+            else:
+                label = key.replace("_", " ").title()
+            labels.append(label)
+            # Use dict.__setitem__() to suppress defenses against double
+            # assignment in enum's classdict.
+            dict.__setitem__(classdict, key, value)
+        cls = super().__new__(metacls, classname, bases, classdict, **kwds)
+        for member, label in zip(cls.__members__.values(), labels):
+            member._label_ = label
+        return enum.unique(cls)
+
+    def __contains__(cls, member):
+        if not isinstance(member, enum.Enum):
+            # Allow non-enums to match against member values.
+            return any(x.value == member for x in cls)
+        return super().__contains__(member)
+
+    @property
+    def names(cls):
+        empty = ["__empty__"] if hasattr(cls, "__empty__") else []
+        return empty + [member.name for member in cls]
+
+    @property
+    def choices(cls):
+        empty = [(None, cls.__empty__)] if hasattr(cls, "__empty__") else []
+        return empty + [(member.value, member.label) for member in cls]
+
+    @property
+    def labels(cls):
+        return [label for _, label in cls.choices]
+
+    @property
+    def values(cls):
+        return [value for value, _ in cls.choices]
+
+
+class Choices(enum.Enum, metaclass=ChoicesMeta):
+    """Class for creating enumerated choices."""
+
+    @DynamicClassAttribute
+    def label(self):
+        return self._label_
+
+    @property
+    def do_not_call_in_templates(self):
+        return True
+
+    def __str__(self):
+        """
+        Use value when cast to str, so that Choices set as model instance
+        attributes are rendered as expected in templates and similar contexts.
+        """
+        return str(self.value)
+
+    # A similar format was proposed for Python 3.10.
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}.{self._name_}"
+
+
+class IntegerChoices(int, Choices):
+    """Class for creating enumerated integer choices."""
+
+    pass
+
+
+class TextChoices(str, Choices):
+    """Class for creating enumerated string choices."""
+
+    def _generate_next_value_(name, start, count, last_values):
+        return name
+
+
+class LicenceActionEnum(TextChoices):
     INSERT = "insert"
     CANCEL = "cancel"
     UPDATE = "update"
 
-    choices = [
-        (INSERT, "Insert"),
-        (CANCEL, "Cancel"),
-        (UPDATE, "Update"),
-    ]
+
+# Django's choices don't support groups, so we are using @classproperty.
+class LicenceTypeEnum(TextChoices):
+    SIEL = "siel", "Standard Individual Export Licence"
+    SICL = "sicl", "Standard Individual Trade Control Licence"
+    SITL = "sitl", "Standard Individual Transhipment Licence"
+    OIEL = "oiel", "Open Individual Export Licence"
+    OICL = "oicl", "Open Individual Trade Control Licence"
+    OGEL = "ogel", "Open General Export Licence"
+    OGCL = "ogcl", "Open General Trade Control Licence"
+    OGTL = "ogtl", "Open General Transhipment Licence"
+
+    @classproperty
+    def STANDARD_LICENCES(cls):
+        return [cls.SIEL, cls.SICL, cls.SITL]
+
+    @classproperty
+    def OPEN_LICENCES(cls):
+        return [cls.OIEL, cls.OICL]
+
+    @classproperty
+    def OPEN_GENERAL_LICENCES(cls):
+        return [cls.OGEL, cls.OGCL, cls.OGTL]
 
 
-class LicenceTypeEnum:
-    SIEL = "siel"
-    SICL = "sicl"
-    SITL = "sitl"
-    OIEL = "oiel"
-    OICL = "oicl"
-    OGEL = "ogel"
-    OGCL = "ogcl"
-    OGTL = "ogtl"
-
-    choices = [
-        (SIEL, "Standard Individual Export Licence"),
-        (SICL, "Standard Individual Trade Control Licence"),
-        (SITL, "Standard Individual Transhipment Licence"),
-        (OIEL, "Open Individual Export Licence"),
-        (OICL, "Open Individual Trade Control Licence"),
-        (OGEL, "Open General Export Licence"),
-        (OGCL, "Open General Trade Control Licence"),
-        (OGTL, "Open General Transhipment Licence"),
-    ]
-
-    STANDARD_LICENCES = [SIEL, SICL, SITL]
-    OPEN_LICENCES = [OIEL, OICL]
-    OPEN_GENERAL_LICENCES = [OGEL, OGCL, OGTL]
+LITE_HMRC_LICENCE_TYPE_MAPPING = {
+    LicenceTypeEnum.SIEL.value: "SIE",
+    LicenceTypeEnum.SICL.value: "SIE",
+    LicenceTypeEnum.SITL.value: "SIE",
+    LicenceTypeEnum.OIEL.value: "OIE",
+    # No OICL?
+    LicenceTypeEnum.OGEL.value: "OGE",
+    LicenceTypeEnum.OGCL.value: "OGE",
+    LicenceTypeEnum.OGTL.value: "OGE",
+}
 
 
-class ReplyStatusEnum:
+class ReplyStatusEnum(TextChoices):
     ACCEPTED = "accepted"
     REJECTED = "rejected"
     PENDING = "pending"
 
-    choices = [
-        (ACCEPTED, "Accepted"),
-        (REJECTED, "Rejected"),
-        (PENDING, "Pending"),
-    ]
 
-
-class ReceptionStatusEnum:
+class ReceptionStatusEnum(TextChoices):
     PENDING = "pending"
     REPLY_PENDING = "reply_pending"
     REPLY_RECEIVED = "reply_received"
     REPLY_SENT = "reply_sent"
 
-    choices = [
-        (PENDING, "Pending"),
-        (REPLY_PENDING, "Reply Pending"),
-        (REPLY_RECEIVED, "Reply Received"),
-        (REPLY_SENT, "Reply Sent"),
-    ]
 
-
-class ExtractTypeEnum:
+class ExtractTypeEnum(TextChoices):
     USAGE_DATA = "usage_data"
     USAGE_REPLY = "usage_reply"
     LICENCE_REPLY = "licence_reply"
     LICENCE_DATA = "licence_data"
 
-    choices = [
-        (USAGE_DATA, "Usage Data"),
-        (USAGE_REPLY, "Usage Reply"),
-        (LICENCE_REPLY, "Licence Reply"),
-        (LICENCE_DATA, "Licence Data"),
-    ]
-
-    email_keys = [
-        ("usageData", USAGE_DATA),
-        ("usageReply", USAGE_REPLY),
-        ("licenceReply", LICENCE_REPLY),
-        ("licenceData", LICENCE_DATA),
-    ]
+    @classproperty
+    def email_keys(cls):
+        return [
+            ("usageData", cls.USAGE_DATA.value),
+            ("usageReply", cls.USAGE_REPLY.value),
+            ("licenceReply", cls.LICENCE_REPLY.value),
+            ("licenceData", cls.LICENCE_DATA.value),
+        ]
 
 
-class SourceEnum:
-    SPIRE = "SPIRE"
-    LITE = "LITE"
-    HMRC = "HMRC"
-
-    choices = [
-        (SPIRE, "SPIRE"),
-        (LITE, "LITE"),
-        (HMRC, "HMRC"),
-    ]
+class SourceEnum(TextChoices):
+    SPIRE = "SPIRE", "SPIRE"
+    LITE = "LITE", "LITE"
+    HMRC = "HMRC", "HMRC"
 
 
-class UnitMapping:
-    number = 30
-    gram = 21
-    kilogram = 23
-    meters_squared = 45
-    meters = 57
-    litre = 94
-    meters_cubed = 2
-    intangible = 30
-
-    choices = [
-        (number, "NAR"),
-        (gram, "GRM"),
-        (kilogram, "KGM"),
-        (meters_squared, "MTK"),
-        (meters, "MTR"),
-        (litre, "LTR"),
-        (meters_cubed, "MTQ"),
-        (intangible, "ITG"),
-    ]
+# We want a duplicate entry for ITG, so cannot use Django's enum.
+class UnitMapping(enum.Enum):
+    NAR = 30  # number
+    GRM = 21  # gram
+    KGM = 23  # kilogram
+    MTK = 45  # meters_squared
+    MTR = 57  # meters
+    LTR = 94  # litre
+    MTQ = 2  # meters_cubed
+    ITG = 30  # intangible
 
     @classmethod
-    def convert(cls, unit) -> int:
-        for k, v in cls.choices:
-            if unit == v:
-                return k
+    def convert(cls, unit):
+        try:
+            return cls[unit].value
+        except KeyError:
+            pass
 
 
-class MailReadStatuses:
+class MailReadStatuses(TextChoices):
     READ = "READ"
     UNREAD = "UNREAD"
     UNPROCESSABLE = "UNPROCESSABLE"
 
-    choices = [(READ, "Read"), (UNREAD, "Unread"), (UNPROCESSABLE, "Unprocessable")]
 
-
-class LicenceStatusEnum:
+class LicenceStatusEnum(TextChoices):
     OPEN = "open"
     EXHAUST = "exhaust"
     SURRENDER = "surrender"
     EXPIRE = "expire"
     CANCEL = "cancel"
-
-    choices = [(OPEN, "open"), (EXHAUST, "exhaust"), (SURRENDER, "surrender"), (EXPIRE, "expire"), (CANCEL, "cancel")]

--- a/mail/libraries/helpers.py
+++ b/mail/libraries/helpers.py
@@ -9,7 +9,7 @@ from dateutil.parser import parse
 from django.conf import settings
 
 from mail import serializers
-from mail.enums import ExtractTypeEnum, LicenceStatusEnum, ReceptionStatusEnum, SourceEnum, UnitMapping
+from mail.enums import ExtractTypeEnum, LicenceStatusEnum, ReceptionStatusEnum, SourceEnum
 from mail.libraries.email_message_dto import EmailMessageDto, HmrcEmailMessageDto
 from mail.models import GoodIdMapping, LicenceData, LicenceIdMapping, Mail, UsageData
 
@@ -218,12 +218,6 @@ def read_file(file_path: str, mode: str = "r", encoding: str = None):
 
 def decode(data, char_set: str):
     return data.decode(char_set) if isinstance(data, bytes) else data
-
-
-def map_unit(data: dict, g: int) -> dict:
-    unit = data["goods"][g]["unit"]
-    data["goods"][g]["unit"] = UnitMapping.convert(unit)
-    return data
 
 
 def select_email_for_sending() -> Mail or None:

--- a/mail/tests/test_enums.py
+++ b/mail/tests/test_enums.py
@@ -1,0 +1,24 @@
+import unittest
+
+from mail.enums import UnitMapping
+
+
+class UnitMappingTests(unittest.TestCase):
+    def test_convert_code(self):
+        data = [
+            ("NAR", 30),
+            ("GRM", 21),
+            ("KGM", 23),
+            ("MTK", 45),
+            ("MTR", 57),
+            ("LTR", 94),
+            ("MTQ", 2),
+            ("ITG", 30),
+        ]
+
+        for code, value in data:
+            with self.subTest(code=code, value=value):
+                self.assertEqual(value, UnitMapping.convert(code))
+
+    def test_convert_none(self):
+        self.assertIsNone(UnitMapping.convert(None))

--- a/mail/tests/test_helpers.py
+++ b/mail/tests/test_helpers.py
@@ -10,7 +10,6 @@ from mail.libraries.helpers import (
     get_country_id,
     get_licence_status,
     get_run_number,
-    map_unit,
     new_hmrc_run_number,
     process_attachment,
 )
@@ -63,37 +62,6 @@ class HelpersTests(LiteHMRCTestClient):
             status=ReceptionStatusEnum.PENDING,
             edi_filename="blank",
         )
-
-    @parameterized.expand(
-        [
-            ("NAR", 30),
-            ("GRM", 21),
-            ("KGM", 23),
-            ("MTK", 45),
-            ("MTR", 57),
-            ("LTR", 94),
-            ("MTQ", 2),
-            ("ITG", 30),
-        ]
-    )
-    def test_convert(self, lite_input, output):
-        self.assertEqual(output, UnitMapping.convert(lite_input))
-
-    @parameterized.expand(
-        [
-            ("NAR", 30),
-            ("GRM", 21),
-            ("KGM", 23),
-            ("MTK", 45),
-            ("MTR", 57),
-            ("LTR", 94),
-            ("MTQ", 2),
-            ("ITG", 30),
-        ]
-    )
-    def test_mapping(self, lite_input, output):
-        data = {"goods": [{"unit": lite_input}]}
-        self.assertEqual(output, map_unit(data, 0)["goods"][0]["unit"])
 
     @parameterized.expand([("GB/00001/P", "00001P"), ("GB/001/P/A", "001PA"), ("GB/0/01/P/a", "001Pa")])
     def test_transaction_reference_for_licence_data(self, reference, transaction_reference):


### PR DESCRIPTION
Django version 3.x added the choice types for use as enums, so I backported
that implementation and used it for the enum things.