### PR TITLE
    ICMSLST-1570 Use positional arguments to logging calls

### DIFF
--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -19,7 +19,7 @@ class HawkOnlyAuthentication(authentication.BaseAuthentication):
         try:
             hawk_receiver = _authenticate(request)
         except HawkFail as e:
-            logging.warning(f"Failed HAWK authentication {e}")
+            logging.warning("Failed HAWK authentication %s", e)
             raise e
 
         return AnonymousUser(), hawk_receiver

--- a/conf/views.py
+++ b/conf/views.py
@@ -23,11 +23,11 @@ class HealthCheck(APIView):
         start_time = time.time()
 
         if not self._is_lite_licence_update_task_responsive():
-            logging.error(f"{LICENCE_DATA_TASK_QUEUE} is not responsive")
+            logging.error("%s is not responsive", LICENCE_DATA_TASK_QUEUE)
             return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, "not OK", start_time)
 
         if not self._is_inbox_polling_task_responsive():
-            logging.error(f"{MANAGE_INBOX_TASK_QUEUE} is not responsive")
+            logging.error("%s is not responsive", MANAGE_INBOX_TASK_QUEUE)
             return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, "not OK", start_time)
 
         pending_mail = self._get_pending_mail()

--- a/mail/libraries/data_converters.py
+++ b/mail/libraries/data_converters.py
@@ -17,7 +17,7 @@ from mail.libraries.helpers import (
 def convert_data_for_licence_data(dto: EmailMessageDto) -> dict:
     source = convert_sender_to_source(dto.sender)
 
-    logging.info(f"Email sender ({dto.sender}) is determined as coming from {source}")
+    logging.info("Email sender (%s) is determined as coming from %s", dto.sender, source)
 
     data = {"licence_data": {}}
     data["licence_data"]["source"] = source

--- a/mail/libraries/helpers.py
+++ b/mail/libraries/helpers.py
@@ -69,7 +69,7 @@ def get_attachment(msg: Message):
             data = part.get_payload(decode=True)
             if name:
                 return name, data
-    logging.info("No attachment found")
+    logger.info("No attachment found")
     return None, None
 
 
@@ -167,7 +167,7 @@ def process_attachment(attachment):
     file_data = attachment[1]
     file_data = file_data.decode("utf-8")
 
-    logging.debug(f"attachment filename: {file_name}, filedata:\n{file_data}")
+    logger.debug("attachment filename: %s, filedata:\n%s", file_name, file_data)
     return file_name, file_data
 
 
@@ -207,7 +207,7 @@ def get_licence_ids(file_body) -> str:
     for line in lines:
         if line and "licence" in line.split("\\")[1]:
             ids.append(line.split("\\")[4])
-    logging.debug(f"licence ids in the file: {ids}")
+    logger.debug("licence ids in the file: %s", ids)
     return json.dumps(ids)
 
 
@@ -221,7 +221,7 @@ def decode(data, char_set: str):
 
 
 def select_email_for_sending() -> Mail or None:
-    logging.info("Selecting email to send")
+    logger.info("Selecting email to send")
 
     reply_received = Mail.objects.filter(status=ReceptionStatusEnum.REPLY_RECEIVED).first()
     if reply_received:
@@ -237,14 +237,14 @@ def select_email_for_sending() -> Mail or None:
             usage_data = UsageData.objects.get(mail=reply_pending)
             if not usage_data.has_spire_data:
                 return reply_pending
-        logging.info("Email currently in flight")
+        logger.info("Email currently in flight")
         return
 
     pending = Mail.objects.filter(status=ReceptionStatusEnum.PENDING).first()
     if pending:
         return pending
 
-    logging.info("No emails to send")
+    logger.info("No emails to send")
     return
 
 

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -166,7 +166,7 @@ def licences_to_edifact(licences: Iterable[LicencePayload], run_number: int) -> 
     )
     lines.append(file_header)
 
-    logging.info(f"File header:{file_header}")
+    logging.info("File header: %r", file_header)
 
     for licence in licences:
         licence_lines = list(generate_lines_for_licence(licence))

--- a/mail/libraries/mailbox_service.py
+++ b/mail/libraries/mailbox_service.py
@@ -37,7 +37,10 @@ def get_message_id(pop3_connection, listing_msg):
 
     if spire_from_address not in msg_header[1] and hmrc_dit_reply_address not in msg_header[1]:
         logging.warning(
-            f"Found mail with message_num {msg_num} that is not from SPIRE ({spire_from_address}) or HMRC ({hmrc_dit_reply_address}), skipping ..."
+            "Found mail with message_num %s that is not from SPIRE (%s) or HMRC (%s), skipping ...",
+            msg_num,
+            spire_from_address,
+            hmrc_dit_reply_address,
         )
         return None, msg_num
 
@@ -56,7 +59,7 @@ def get_message_id(pop3_connection, listing_msg):
                 value = value.replace("<", "").replace(">", "").strip(" ")
                 message_id = value.split("@")[0]
 
-    logging.info(f"Extracted Message-Id as {message_id} for the message_num {msg_num}")
+    logging.info("Extracted Message-Id as %s for the message_num %s", message_id, msg_num)
     return message_id, msg_num
 
 
@@ -83,7 +86,7 @@ def get_message_iterator(pop3_connection: POP3_SSL, username: str) -> Iterator[T
 
     # these are mailbox message ids we've seen before
     read_messages = get_read_messages(mailbox_config)
-    logging.info(f"Number of messages READ/UNPROCESSABLE in {mailbox_config.username} are {len(read_messages)}")
+    logging.info("Number of messages READ/UNPROCESSABLE in %s are %s", mailbox_config.username, len(read_messages))
 
     for message_id, message_num in mail_message_ids:
         # only return messages we haven't seen before
@@ -97,7 +100,11 @@ def get_message_iterator(pop3_connection: POP3_SSL, username: str) -> Iterator[T
                 :param status: A choice from `MailReadStatuses.choices`
                 """
                 logging.info(
-                    f"Marking message_id {message_id} with message_num {message_num} from {read_status.mailbox.username} as {status}"
+                    "Marking message_id %s with message_num %s from %s as %s",
+                    message_id,
+                    message_num,
+                    read_status.mailbox.username,
+                    status,
                 )
                 read_status.status = status
                 read_status.save()
@@ -105,11 +112,18 @@ def get_message_iterator(pop3_connection: POP3_SSL, username: str) -> Iterator[T
             try:
                 m = pop3_connection.retr(message_num)
                 logging.info(
-                    f"Retrieved message_id {message_id} with message_num {message_num} from {read_status.mailbox.username}"
+                    "Retrieved message_id %s with message_num %s from %s",
+                    message_id,
+                    message_num,
+                    read_status.mailbox.username,
                 )
             except error_proto as err:
                 logging.error(
-                    f"Unable to RETR message num {message_num} with Message-ID {message_id} in {mailbox_config}: {err}",
+                    "Unable to RETR message num %s with Message-ID %s in %s: %s",
+                    message_num,
+                    message_id,
+                    mailbox_config,
+                    err,
                     exc_info=True,
                 )
                 continue
@@ -118,7 +132,11 @@ def get_message_iterator(pop3_connection: POP3_SSL, username: str) -> Iterator[T
                 mail_message = to_mail_message_dto(m)
             except ValueError as ve:
                 logging.error(
-                    f"Unable to convert message num {message_id} with Message-Id {message_id} to DTO in {mailbox_config}: {ve}",
+                    "Unable to convert message num %s with Message-Id %s to DTO in %s: %s",
+                    message_num,
+                    message_id,
+                    mailbox_config,
+                    ve,
                     exc_info=True,
                 )
                 mark_status(MailReadStatuses.UNPROCESSABLE)
@@ -169,8 +187,8 @@ def find_mail_of(extract_types: List[str], reception_status: str) -> Mail or Non
     try:
         mail = Mail.objects.get(status=reception_status, extract_type__in=extract_types)
     except Mail.DoesNotExist:
-        logging.warning(f"Can not find any mail in [{reception_status}] of extract type [{extract_types}]")
+        logging.warning("Can not find any mail in [%s] of extract type [%s]", reception_status, extract_types)
         return
 
-    logging.info(f"Found mail in [{reception_status}] of extract type [{extract_types}] ")
+    logging.info("Found mail in [%s] of extract type [%s]", reception_status, extract_types)
     return mail

--- a/mail/libraries/routing_controller.py
+++ b/mail/libraries/routing_controller.py
@@ -83,7 +83,7 @@ def check_and_route_emails():
     hmrc_to_dit_server = get_hmrc_to_dit_mailserver()
     email_message_dtos = _get_email_message_dtos(hmrc_to_dit_server, number=None)
     email_message_dtos = sort_dtos_by_date(email_message_dtos)
-    logging.info("Incoming message dtos sorted by date: %s" % email_message_dtos)
+    logger.info("Incoming message dtos sorted by date: %s", email_message_dtos)
 
     spire_to_dit_server = get_spire_to_dit_mailserver()
     if hmrc_to_dit_server != spire_to_dit_server:
@@ -92,19 +92,21 @@ def check_and_route_emails():
         # same emails.
         reply_message_dtos = _get_email_message_dtos(spire_to_dit_server)
         reply_message_dtos = sort_dtos_by_date(reply_message_dtos)
-        logging.info("Reply message dtos sorted by date: %s" % reply_message_dtos)
+        logger.info("Reply message dtos sorted by date: %s", reply_message_dtos)
 
         email_message_dtos.extend(reply_message_dtos)
 
     if not email_message_dtos:
         pending_message = check_for_pending_messages()
         if pending_message:
-            logging.info(
-                f"Found pending mail ({pending_message.id}) of extract type {pending_message.extract_type} for sending"
+            logger.info(
+                "Found pending mail (%s) of extract type %s for sending",
+                pending_message.id,
+                pending_message.extract_type,
             )
             _collect_and_send(pending_message)
 
-        logger.info(f"No new emails found from {hmrc_to_dit_server.user} or {spire_to_dit_server.user}")
+        logger.info("No new emails found from %s or %s", hmrc_to_dit_server.user, spire_to_dit_server.user)
 
         publish_queue_status()
 
@@ -112,19 +114,22 @@ def check_and_route_emails():
 
     for email, mark_status in email_message_dtos:
         try:
-            logging.info(f"Processing mail with subject {email.subject}")
+            logger.info("Processing mail with subject", email.subject)
             serialize_email_message(email)
             mark_status(MailReadStatuses.READ)
         except ValidationError as ve:
-            logger.info(f"Marking message {email.subject} as UNPROCESSABLE. {ve.detail}")
+            logger.info("Marking message %s as UNPROCESSABLE. %s", email.subject, ve.detail)
             mark_status(MailReadStatuses.UNPROCESSABLE)
 
     logger.info("Finished checking for emails")
 
     mail = select_email_for_sending()  # Can return None in the event of in flight or no pending or no reply_received
     if mail:
-        logging.info(
-            f"Selected mail ({mail.id}) for sending, extract type {mail.extract_type}, current status {mail.status}"
+        logger.info(
+            "Selected mail (%s) for sending, extract type %s, current status %s",
+            mail.id,
+            mail.extract_type,
+            mail.status,
         )
         _collect_and_send(mail)
 
@@ -153,13 +158,13 @@ def update_mail(mail: Mail, mail_dto: EmailMessageDto):
         mail.sent_response_filename = mail_dto.attachment[0]
         mail.sent_response_data = mail_dto.attachment[1]
 
-    logging.info(f"Updating Mail {mail.id} status from {previous_status} => {mail.status}")
+    logger.info("Updating Mail %s status from %s => %s", mail.id, previous_status, mail.status)
 
     mail.save()
 
 
 def send(server: MailServer, email_message_dto: EmailMessageDto):
-    logging.info("Preparing to send email")
+    logger.info("Preparing to send email")
     smtp_connection = server.connect_to_smtp()
     send_email(smtp_connection, build_email_message(email_message_dto))
     server.quit_smtp_connection()
@@ -168,13 +173,13 @@ def send(server: MailServer, email_message_dto: EmailMessageDto):
 def _collect_and_send(mail: Mail):
     from mail.tasks import send_licence_data_to_hmrc
 
-    logger.info(f"Sending Mail [{mail.id}] of extract type {mail.extract_type}")
+    logger.info("Sending Mail [%s] of extract type %s", mail.id, mail.extract_type)
 
     message_to_send_dto = to_email_message_dto_from(mail)
     is_locked_by_me = lock_db_for_sending_transaction(mail)
 
     if not is_locked_by_me:
-        logger.info(f"Mail [{mail.id}] is being sent by another thread")
+        logger.info("Mail [%s] is being sent by another thread", mail.id)
 
     if message_to_send_dto:
         if message_to_send_dto.receiver != SourceEnum.LITE and message_to_send_dto.subject:
@@ -183,7 +188,11 @@ def _collect_and_send(mail: Mail):
             update_mail(mail, message_to_send_dto)
 
             logger.info(
-                f"Mail [{mail.id}] routed from [{message_to_send_dto.sender}] to [{message_to_send_dto.receiver}] with subject {message_to_send_dto.subject}"
+                "Mail [%s] routed from [%s] to [%s] with subject %s",
+                mail.id,
+                message_to_send_dto.sender,
+                message_to_send_dto.receiver,
+                message_to_send_dto.subject,
             )
         else:
             update_mail(mail, message_to_send_dto)

--- a/mail/management/commands/resend_email.py
+++ b/mail/management/commands/resend_email.py
@@ -86,11 +86,10 @@ class Command(BaseCommand):
             logger.error("Given run number %s does not belong to Licence data or Usage data mail", hmrc_run_number)
             return
 
-        """
-        Usually we resend in cases where the mail is initially sent from our system successfully but not received
-        by the recipient. This could happen with HMRC in case of licence data mails and with SPIRE in
-        case of licence reply mails. Below we check for their expected status and set destination.
-        """
+        # Usually we resend in cases where the mail is initially sent from our system successfully but not received
+        # by the recipient. This could happen with HMRC in case of licence data mails and with SPIRE in
+        # case of licence reply mails. Below we check for their expected status and set destination.
+
         # this is the usual case where we had to resend
         if mail.extract_type == ExtractTypeEnum.LICENCE_DATA:
             destination = SourceEnum.HMRC

--- a/mail/requests.py
+++ b/mail/requests.py
@@ -80,11 +80,12 @@ def verify_api_response(sender, response):
             content_type=response.headers["Content-Type"],
         )
     except Exception as exc:  # noqa
-        logging.warning(f"Unable to authenticate response from {response.url}")
+        logging.warning("Unable to authenticate response from %s", response.url)
 
         if "server-authorization" not in response.headers:
             logging.warning(
-                f"'server_authorization' missing in header from response {response.url}; Probable HAWK misconfiguration"
+                "'server_authorization' missing in header from response %s; Probable HAWK misconfiguration",
+                response.url,
             )
 
         raise exc

--- a/mail/tests/libraries/client.py
+++ b/mail/tests/libraries/client.py
@@ -24,7 +24,6 @@ class LiteHMRCTestClient(testcases.TestCase):
             b"AwMDAwMDEvUAo0XGZpbGVUcmFpbGVyXDJcMFww"
         )
         self.usage_data_reply_body = read_file("mail/tests/files/usage_data_reply_file", mode="rb")
-        logging.debug("licence_data_reply_body: \n{}".format(self.licence_data_reply_body))
         self.licence_data_reply_name = "ILBDOTI_live_CHIEF_licenceReply_49543_201902080025"
 
         self.usage_data_reply_name = "ILBDOTI_live_CHIEF_usageReply_49543_201902080025"

--- a/mail/tests/test_data_processors.py
+++ b/mail/tests/test_data_processors.py
@@ -101,7 +101,6 @@ class TestDataProcessors(LiteHMRCTestClient):
 
         serialize_email_message(email_message_dto)
         self.mail.refresh_from_db()
-        logging.debug("resp data: {}".format(self.mail.response_data))
         self.assertEqual(self.mail.status, ReceptionStatusEnum.REPLY_RECEIVED)
         self.assertIsNotNone(self.mail.response_date)
 

--- a/mock_hmrc/data_processors.py
+++ b/mock_hmrc/data_processors.py
@@ -23,7 +23,7 @@ def save_hmrc_email_message_data(dto):
     extract_type = get_extract_type(dto.subject)
     if not extract_type:
         update_retrieved_email_status(dto, enums.RetrievedEmailStatusEnum.INVALID)
-        logging.info(f"Extract type not supported ({dto.subject}), skipping")
+        logging.info("Extract type not supported (%s), skipping", dto.subject)
         return None
 
     data = convert_dto_data_for_serialization(dto, extract_type)


### PR DESCRIPTION
The stdlib's logging library is intended to be used with positional arguments,
so that a call that doesn't emit a message can skip formatting.

There were also some totally useless logging calls that have been removed.
