### PR TITLE
Fix CI pipeline failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  jq: circleci/jq@1.8.0
-
 jobs:
   tests:
     docker:
@@ -20,26 +17,8 @@ jobs:
     working_directory: ~/lite-hmrc
 
     steps:
-      - jq/install
-
       - checkout
 
-#      - run:
-#          name: Repository Vulnerability Check
-#          command: |
-#            VULNERABILITY_COUNT=`curl -s -u "lite-cicircle:${CICIRCLE_PERSONAL_ACCESS_TOKEN}" \
-#              -X POST -H "Content-Type: application/json" \
-#              -H "Accept: application/vnd.github.vixen-preview+json" \
-#              -d '{"query": "query { repository(owner:\"uktrade\" name:\"lite-hmrc\") { vulnerabilityAlerts(first: 100) { totalCount } } }"}' \
-#              https://api.github.com/graphql | jq ".data.repository.vulnerabilityAlerts.totalCount"`
-#            if [ "$VULNERABILITY_COUNT" = "0" ]; then
-#              echo "No vulnerabilities found"
-#            elif [ "$VULNERABILITY_COUNT" = "null" ]; then
-#              echo "Vulnerability check query returned unexpected JSON - bad credentials? Check JSON response for details"
-#            else
-#              echo "Vulnerabilities found: $VULNERABILITY_COUNT. Check GitHub security tab for details (only visible to admin users)"
-#            fi
-#            exit $VULNERABILITY_COUNT
       - run:
           name: Set Environment File
           command: cp local.env .env


### PR DESCRIPTION
The pipeline tests failed with "Directory (/home/circleci/lite-hmrc) you are
trying to checkout to is not empty and not a git repository". And it turns
out there's a /home/circleci/lite-hmrc/jq-1.5 directory in there. But we
don't even use jq!