### PR TITLE
ICMSLST-1627 Catch invalid licence data

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -179,11 +179,9 @@ class UnitMapping(enum.Enum):
     ITG = 30  # intangible
 
     @classmethod
-    def convert(cls, unit):
-        try:
-            return cls[unit].value
-        except KeyError:
-            pass
+    def serializer_choices(cls):
+        # Used by the API serializer for validation.
+        return list(cls.__members__.keys())
 
 
 class MailReadStatuses(TextChoices):

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -123,14 +123,16 @@ def generate_lines_for_licence(licence):
                 )
                 controlled_by = "Q"  # usage is controlled by quantity only
                 quantity = commodity.get("quantity")
-                if commodity.get("unit") == "NAR":
+                qunit = UnitMapping[commodity["unit"]]
+
+                if qunit == UnitMapping.NAR:
                     quantity = int(quantity)
 
                 yield chieftypes.LicenceDataLine(
                     line_num=g,
                     goods_description=commodity.get("name"),
                     controlled_by=controlled_by,
-                    quantity_unit="{:03d}".format(UnitMapping.convert(commodity.get("unit"))),
+                    quantity_unit="{:03d}".format(qunit.value),
                     quantity_issued=quantity,
                 )
 

--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -140,10 +140,11 @@ class UsageDataMailSerializer(serializers.ModelSerializer):
 
 
 class GoodSerializer(serializers.Serializer):
+    id = serializers.UUIDField(required=False)
     name = serializers.CharField()
     description = serializers.CharField(max_length=2000, allow_blank=True)
     quantity = serializers.DecimalField(decimal_places=3, max_digits=13)
-    unit = serializers.CharField()
+    unit = serializers.ChoiceField(choices=enums.UnitMapping.serializer_choices())
 
 
 class CountrySerializer(serializers.Serializer):

--- a/mail/tests/test_enums.py
+++ b/mail/tests/test_enums.py
@@ -18,7 +18,14 @@ class UnitMappingTests(unittest.TestCase):
 
         for code, value in data:
             with self.subTest(code=code, value=value):
-                self.assertEqual(value, UnitMapping.convert(code))
+                self.assertEqual(value, UnitMapping[code].value)
 
     def test_convert_none(self):
-        self.assertIsNone(UnitMapping.convert(None))
+        with self.assertRaises(KeyError):
+            UnitMapping[None]
+
+    def test_serializer_choices(self):
+        choices = UnitMapping.serializer_choices()
+        expected = ["NAR", "GRM", "KGM", "MTK", "MTR", "LTR", "MTQ", "ITG"]
+
+        self.assertEqual(choices, expected)

--- a/mail/tests/test_helpers.py
+++ b/mail/tests/test_helpers.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 from parameterized import parameterized
 
-from mail.enums import ExtractTypeEnum, ReceptionStatusEnum, SourceEnum, UnitMapping
+from mail.enums import ExtractTypeEnum, ReceptionStatusEnum, SourceEnum
 from mail.libraries.helpers import (
     convert_sender_to_source,
     convert_source_to_sender,


### PR DESCRIPTION
The CHIEF message serializer requires certain fields have certain values,
but the API was not enforcing that.

- goods/unit must be one of the known values.
- goods/id must be a UUID value.