### PR TITLE
Fix hawk authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ An `.env` file is expected at the root of project.
 
 Copy the template .env file: `cp local.env .env`
 
+Copy the template local_settings.sample if required: `cp local_settings.sample local_settings.py`
+
+
 ### Running in Docker
 To run in docker do the following
 - Configure .env file - Using local.env as a starting point:

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -46,7 +46,7 @@ def _authenticate(request):
     Raises a HawkFail exception if the passed request cannot be authenticated
     """
 
-    if settings.HAWK_AUTHENTICATION_ENABLED:
+    if hawk_authentication_enabled():
         return Receiver(
             _lookup_credentials,
             request.META["HTTP_HAWK_AUTHENTICATION"],
@@ -91,3 +91,14 @@ def _lookup_credentials(access_key_id):
         "algorithm": "sha256",
         **credentials,
     }
+
+
+def hawk_authentication_enabled() -> bool:
+    """Defined as method as you can't override settings.HAWK_AUTHENTICATION_ENABLED correctly in tests.
+
+    Patch this function to get desired behaviour.
+    See here for reason:
+    https://stackoverflow.com/questions/29367043/unit-testing-django-rest-framework-authentication-at-runtime
+    """
+
+    return settings.HAWK_AUTHENTICATION_ENABLED

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -225,6 +225,9 @@ if env.str("SENTRY_DSN", ""):
         integrations=[DjangoIntegration()],
         send_default_pii=True,
     )
+    SENTRY_ENABLED = True
+else:
+    SENTRY_ENABLED = False
 
 # Application Performance Monitoring
 if env.str("ELASTIC_APM_SERVER_URL", ""):

--- a/conf/tests/test_authentication.py
+++ b/conf/tests/test_authentication.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+
+# override_settings doesn't work - left here for reference
+# @override_settings(HAWK_AUTHENTICATION_ENABLED=True)
+@patch("conf.authentication.hawk_authentication_enabled", lambda: True)
+class TestHawkAuthentication(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # test endpoint that retrieves licence details
+        cls.test_url = reverse("mail:licence")
+
+    def test_hawk_authentication_returns_401(self):
+        resp = self.client.get(self.test_url)
+
+        # This will trigger an unknown Exception (as HTTP_HAWK_AUTHENTICATION isn't set)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        # This will trigger a HawkException as HTTP_HAWK_AUTHENTICATION is invalid
+        hawk_header = 'Hawk mac="", hash="", id="lite-api", ts="", nonce=""'
+        resp = self.client.get(self.test_url, HTTP_HAWK_AUTHENTICATION=hawk_header)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/local_settings.sample
+++ b/local_settings.sample
@@ -1,0 +1,25 @@
+from conf.settings import *  # noqa
+
+# Remove all json logging
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+        "conf": {"handlers": ["console"], "level": "DEBUG"},
+        "mail": {"handlers": ["console"], "level": "DEBUG"},
+        # Enable if having issues with mohawk
+        # "mohawk": {
+        #     'handlers': ['console'],
+        #     "level": "DEBUG"
+        # }
+    },
+}

--- a/mail/requests.py
+++ b/mail/requests.py
@@ -12,6 +12,8 @@ from django.core.cache import cache
 from mohawk import Sender
 from mohawk.exc import AlreadyProcessed
 
+from conf.authentication import hawk_authentication_enabled
+
 
 class RequestException(Exception):
     """Exceptions to raise when sending requests."""
@@ -37,7 +39,7 @@ def make_request(method, url, data=None, headers=None, hawk_credentials=None, ti
     headers = headers or {}  # If no headers are supplied, default to an empty dictionary
     headers["content-type"] = "application/json"
 
-    if settings.HAWK_AUTHENTICATION_ENABLED:
+    if hawk_authentication_enabled():
         if not hawk_credentials:
             raise RequestException("'hawk_credentials' must be specified when 'HAWK_AUTHENTICATION_ENABLED' is 'True'")
 

--- a/mail/views.py
+++ b/mail/views.py
@@ -2,9 +2,8 @@ import logging
 from typing import TYPE_CHECKING, Type
 
 from django.conf import settings
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from rest_framework import status
-from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from conf.authentication import HawkOnlyAuthentication
@@ -16,6 +15,9 @@ from mail.tasks import send_licence_data_to_hmrc
 
 if TYPE_CHECKING:
     from rest_framework.serializers import Serializer  # noqa
+
+
+logger = logging.getLogger(__name__)
 
 
 class LicenceDataIngestView(APIView):
@@ -56,7 +58,7 @@ class LicenceDataIngestView(APIView):
             ),
         )
 
-        logging.info("Created LicencePayload [%s, %s, %s]", licence.lite_id, licence.reference, licence.action)
+        logger.info("Created LicencePayload [%s, %s, %s]", licence.lite_id, licence.reference, licence.action)
 
         return JsonResponse(
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
@@ -73,44 +75,48 @@ class LicenceDataIngestView(APIView):
 
 
 class SendLicenceUpdatesToHmrc(APIView):
+    authentication_classes = (HawkOnlyAuthentication,)
+
     def get(self, _):
-        """
-        Force the task of sending licence data to HMRC (I assume for testing?)
-        """
+        """Force the task of sending licence data to HMRC (I assume for testing?)"""
+
         success = send_licence_data_to_hmrc.now()
         if success:
-            return HttpResponse(status=status.HTTP_200_OK)
+            return JsonResponse({}, status=status.HTTP_200_OK)
         else:
-            return HttpResponse(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return JsonResponse({}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class SetAllToReplySent(APIView):
-    """
-    Updates status of all emails to REPLY_SENT
-    """
+    """Updates status of all emails to REPLY_SENT"""
+
+    authentication_classes = (HawkOnlyAuthentication,)
 
     def get(self, _):
         Mail.objects.all().update(status=ReceptionStatusEnum.REPLY_SENT)
-        return HttpResponse(status=status.HTTP_200_OK)
+        return JsonResponse({}, status=status.HTTP_200_OK)
 
 
 class Licence(APIView):
+    authentication_classes = (HawkOnlyAuthentication,)
+
     def get(self, request):
-        """
-        Fetch existing licence
-        """
+        """Fetch existing licence"""
         license_ref = request.GET.get("id", "")
 
         matching_licences = LicenceData.objects.filter(licence_ids__contains=license_ref)
         matching_licences_count = matching_licences.count()
+
         if matching_licences_count > 1:
-            logging.warn("Too many matches for licence '%s'", license_ref)
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+            logger.warning("Too many matches for licence '%s'", license_ref)
+            return JsonResponse({}, status=status.HTTP_400_BAD_REQUEST)
+
         elif matching_licences_count == 0:
-            logging.warn("No matches for licence '%s'", license_ref)
-            return Response(status=status.HTTP_404_NOT_FOUND)
+            logger.warning("No matches for licence '%s'", license_ref)
+            return JsonResponse({}, status=status.HTTP_404_NOT_FOUND)
 
         # Return single matching licence
         mail = matching_licences.first().mail
         serializer = MailSerializer(mail)
+
         return JsonResponse(serializer.data)


### PR DESCRIPTION
Changes:

- Return correct exception when authentication fails for any reason
- Add authentication classes to app endpoints (even if they are only used in testing)
- Add local_settings sample to reduce logging output (remove json formatter).