### PR TITLE
ICMSLST-1661 Add Sanction licence data serializer and edifact converter.

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -110,6 +110,7 @@ class LicenceTypeEnum(TextChoices):
     IMPORT_DFL = "DFL", "Deactivated Firearms Licence"
     IMPORT_OIL = "OIL", "Open Individual Import Licence"
     IMPORT_SIL = "SIL", "Specific Individual Import Licence"
+    IMPORT_SAN = "SAN", "Sanctions and Adhoc Import Licence"
 
     @classproperty
     def STANDARD_LICENCES(cls):
@@ -137,6 +138,7 @@ LITE_HMRC_LICENCE_TYPE_MAPPING = {
     LicenceTypeEnum.IMPORT_DFL.value: "SIL",
     LicenceTypeEnum.IMPORT_OIL.value: "OIL",
     LicenceTypeEnum.IMPORT_SIL.value: "SIL",
+    LicenceTypeEnum.IMPORT_SAN.value: "SAN",
 }
 
 
@@ -211,3 +213,145 @@ class LicenceStatusEnum(TextChoices):
     SURRENDER = "surrender"
     EXPIRE = "expire"
     CANCEL = "cancel"
+
+
+# Chief "controlledBy" field
+class ControlledByEnum(TextChoices):
+    VALUE_AND_QUANTITY = "B", "Both Value and Quantity"
+    OPEN = "O", "Open (no usage recording or control)"
+    QUANTITY = "Q", "Quantity Only"
+    VALUE = "V", "Value Only"
+
+
+# Chief "quantityUnit" field
+# https://www.gov.uk/government/publications/uk-trade-tariff-quantity-codes/uk-trade-tariff-quantity-codes
+class QuantityCodeEnum(IntegerChoices):
+    """Quantity codes known by HMRC.
+
+    Only values seen in ICMS have been enabled - Uncomment others as required.
+    """
+
+    # 1. Weight
+    # Ounce = 11, "Ounce"
+    # Pound = 12, "Pound"
+    # Cental (100lb) = 13, "Cental (100lb)"
+    # Cwt = 14, "Cwt"
+    # 1,000lb = 15, "1,000lb"
+    # Ton = 16, "Ton"
+    # Oz Troy = 17, "Oz Troy"
+    # Lb Troy = 18, "Lb Troy"
+    # Gramme = 21, "Gramme"
+    # Hectogramme (100 gms) = 22, "Hectogramme (100 gms)"
+    KILOGRAMME = 23, "Kilogramme"
+    # 100 kgs = 24, "100 kgs"
+    # Tonne = 25, "Tonne"
+    # Metric Carat = 26, "Metric Carat"
+    # 50 kgs = 27, "50 kgs"
+
+    # 2. Gross weight
+    # Pound gross = 60, "Pound gross"
+    # Kilogramme gross = 61, "Kilogramme gross"
+    # Quintal (100 kgs) gross = 62, "Quintal (100 kgs) gross"
+
+    # 3. Unit
+    NUMBER = 30, "Number"
+    PAIR = 31, "Pair"
+    # Dozen = 32, "Dozen"
+    # Dozen Pair = 33, "Dozen Pair"
+    # Hundred = 34, "Hundred"
+    # Long Hundred = 35, "Long Hundred"
+    # Gross = 36, "Gross"
+    # Thousand = 37, "Thousand"
+    # Short Standard = 38, "Short Standard"
+
+    # 4. Area
+    # Square inch = 41, "Square inch"
+    # Square foot = 42, "Square foot"
+    # Square yard = 43, "Square yard"
+    # Square decimetre = 44, "Square decimetre"
+    SQUARE_METRE = 45, "Square metre"
+    # 100 square metres = 46, "100 square metres"
+
+    # 5. Length
+    # Inch = 50, "Inch"
+    # Foot = 51, "Foot"
+    # Yard = 52, "Yard"
+    # 100 feet = 53, "100 feet"
+    # Millimetre = 54, "Millimetre"
+    # Centimetre = 55, "Centimetre"
+    # Decimetre = 56, "Decimetre"
+    # Metre = 57, "Metre"
+    # Dekametre = 58, "Dekametre"
+    # Hectometre = 59, "Hectometre"
+
+    # 6. Capacity
+    # Pint = 71, "Pint"
+    # Gallon = 72, "Gallon"
+    # 36 gallons (Bulk barrel) = 73, "36 gallons (Bulk barrel)"
+    # Millilitre (cu centimetre) = 74, "Millilitre (cu centimetre)"
+    # Centilitre = 75, "Centilitre"
+    # Litre = 76, "Litre"
+    # Dekalitre = 77, "Dekalitre"
+    # Hectolitre = 78, "Hectolitre"
+    # US Gallon = 79, "US Gallon"
+    # 1000 litre = 40, "1000 litre"
+
+    # 7. Volume
+    # Cubic inch = 81, "Cubic inch"
+    # Cubic foot = 82, "Cubic foot"
+    # Cubic yard = 83, "Cubic yard"
+    # Standard = 84, "Standard"
+    # Piled cubic fathom = 85, "Piled cubic fathom"
+    # Cubic decimetre = 86, "Cubic decimetre"
+    CUBIC_METRE = 87, "Cubic metre"
+    # Piled cubic metre = 88, "Piled cubic metre"
+    # Gram fissile isotopes = 89, "Gram fissile isotopes"
+
+    # 8. Various
+    # Kilogramme of H2O2 = 29, "Kilogramme of H2O2"
+    # Kilogramme of K2O = 01, "Kilogramme of K2O"
+    # Kilogramme of KOH = 02, "Kilogramme of KOH"
+    # Kilogramme of N = 03, "Kilogramme of N"
+    # Kilogramme of NaOH = 04, "Kilogramme of NaOH"
+    # Kilogramme of P2O5 = 05, "Kilogramme of P2O5"
+    # Kilogramme of U = 06, "Kilogramme of U"
+    # Kilogramme of WO3 = 07, "Kilogramme of WO3"
+    # Number of flasks = 08, "Number of flasks"
+    # Number of kits = 09, "Number of kits"
+    # Number of rolls = 10, "Number of rolls"
+    # Number of sets = 19, "Number of sets"
+    # 100 packs = 20, "100 packs"
+    # 1000 tablets = 28, "1000 tablets"
+    # 100 kilogram net dry matter = 48, "100 kilogram net dry matter"
+    # 100 kilogram drained net weight = 49, "100 kilogram drained net weight"
+    # Kilogram of choline chloride = 107, "Kilogram of choline chloride"
+    # Kilogram of methyl amines = 39, "Kilogram of methyl amines"
+    # Kilogramme of total alcohol = 63, "Kilogramme of total alcohol"
+    # CCT carrying capacity in Tonnes (metric) shipping = 64, "CCT carrying capacity in Tonnes (metric) shipping"
+    # Gram (fine gold content) = 65, "Gram (fine gold content)"
+    # Litre of alcohol = 66, "Litre of alcohol"
+    # Litre of alcohol in the spirit = 66, "Litre of alcohol in the spirit"
+    # Litre of pure 100% alcohol = 66, "Litre of pure 100% alcohol"
+    # Kilogramme 90% dry = 67, "Kilogramme 90% dry"
+    # 90% tonne dry = 68, "90% tonne dry"
+    # Kilogramme drained net weight = 69, "Kilogramme drained net weight"
+    # Standard litre (of hydrocarbon oil) = 70, "Standard litre (of hydrocarbon oil)"
+    # 1000 cubic metres = 80, "1000 cubic metres"
+    # Curie = 90, "Curie"
+    # Proof gallon = 91, "Proof gallon"
+    # Displacement tonnage = 92, "Displacement tonnage"
+    # Gross tonnage = 93, "Gross tonnage"
+    # 100 international units = 94, "100 international units"
+    # Million international units potency = 95, "Million international units potency"
+    # Kilowatt = 96, "Kilowatt"
+    # Kilowatt hour = 97, "Kilowatt hour"
+    # Alcohol by Volume (ABV%) Beer = 98, "Alcohol by Volume (ABV%) Beer"
+    # Degrees (Percentage Volume) = 99, "Degrees (Percentage Volume)"
+    # TJ (gross calorific value) = 120, "TJ (gross calorific value)"
+    # Euro per tonne of fuel = 112, "Euro per tonne of fuel"
+    # Euro per tonne net of biodiesel content = 113, "Euro per tonne net of biodiesel content"
+    # Kilometres = 114, "Kilometres"
+    # Euro per tonne net of bioethanol content = 115, "Euro per tonne net of bioethanol content"
+    # Number of watt = 117, "Number of watt"
+    # Kilogram Raw Sugar = 118, "Kilogram Raw Sugar"
+    # KAC: (KG net of Acesulfame Potassium) = 119, "KAC: (KG net of Acesulfame Potassium)"

--- a/mail/tests/files/icms/icms_chief_licence_data_file_sanction
+++ b/mail/tests/files/icms/icms_chief_licence_data_file_sanction
@@ -1,0 +1,10 @@
+1\fileHeader\ILBDOTI\CHIEF\licenceData\202201011011\1\N
+2\licence\IMA/2022/00004\insert\GBSAN4444444A\SAN\I\20220629\20241229
+3\trader\112233445566\\\\Sanction Organisation\line_1\line_2\line_3\\\S227ZZ
+4\country\RU\\O
+5\restrictions\
+6\line\1\7214993100\\\\\Q\\023\\26710\\\\\\
+7\line\2\7214997100\\\\\Q\\023\\48042\\\\\\
+8\line\3\7215508000\\\\\Q\\023\\4952\\\\\\
+9\end\licence\8
+10\fileTrailer\1

--- a/mail/tests/test_builders.py
+++ b/mail/tests/test_builders.py
@@ -226,11 +226,11 @@ class TestBuildICMSLicenceDataFASIL(testcases.TestCase):
         restrictions = "Sample restrictions"
 
         goods = [
-            {"description": "Sample goods description 1", "quantity": 1, "controlled_by": "Q"},
-            {"description": "Sample goods description 2", "quantity": 2, "controlled_by": "Q"},
-            {"description": "Sample goods description 3", "quantity": 3, "controlled_by": "Q"},
-            {"description": "Sample goods description 4", "quantity": 4, "controlled_by": "Q"},
-            {"description": "Sample goods description 5", "quantity": 5, "controlled_by": "Q"},
+            {"description": "Sample goods description 1", "quantity": 1, "controlled_by": "Q", "unit": 30},
+            {"description": "Sample goods description 2", "quantity": 2, "controlled_by": "Q", "unit": 30},
+            {"description": "Sample goods description 3", "quantity": 3, "controlled_by": "Q", "unit": 30},
+            {"description": "Sample goods description 4", "quantity": 4, "controlled_by": "Q", "unit": 30},
+            {"description": "Sample goods description 5", "quantity": 5, "controlled_by": "Q", "unit": 30},
             {"description": "Unlimited Description goods line", "controlled_by": "O"},
         ]
 
@@ -251,6 +251,64 @@ class TestBuildICMSLicenceDataFASIL(testcases.TestCase):
         )
 
         self.test_file = Path("mail/tests/files/icms/icms_chief_licence_data_file_fa_sil")
+        self.assertTrue(self.test_file.is_file())
+
+    def test_generate_icms_licence_file(self):
+        licences = LicencePayload.objects.all()
+        self.assertEqual(licences.count(), 1)
+
+        run_number = 1
+        when = datetime.datetime(2022, 1, 1, 10, 11, 00)
+
+        filename, file_content = builders.build_licence_data_file(licences, run_number, when)
+
+        self.assertEqual(filename, f"CHIEF_LIVE_ILBDOTI_licenceData_1_202201011011")
+
+        self.maxDiff = None
+        expected_content = self.test_file.read_text()
+        self.assertEqual(expected_content, file_content)
+
+
+@override_settings(CHIEF_SOURCE_SYSTEM=ChiefSystemEnum.ICMS)
+class TestBuildICMSLicenceDataSanction(testcases.TestCase):
+    def setUp(self) -> None:
+        org_data = {
+            "eori_number": "112233445566",
+            "name": "Sanction Organisation",
+            "address": {
+                "line_1": "line_1",
+                "line_2": "line_2",
+                "line_3": "line_3",
+                "line_4": "",
+                "line_5": "",
+                "postcode": "S227ZZ",
+            },
+        }
+
+        restrictions = ""
+        goods = [
+            {"commodity": "7214993100", "quantity": 26710, "controlled_by": "Q", "unit": 23},
+            {"commodity": "7214997100", "quantity": 48042, "controlled_by": "Q", "unit": 23},
+            {"commodity": "7215508000", "quantity": 4952, "controlled_by": "Q", "unit": 23},
+        ]
+
+        LicencePayload.objects.create(
+            lite_id="4277dd90-7ac0-4f48-b228-94c4a2fc61b2",
+            reference="GBSAN4444444A",
+            action=LicenceActionEnum.INSERT,
+            data={
+                "type": LicenceTypeEnum.IMPORT_SAN.value,
+                "case_reference": "IMA/2022/00004",
+                "start_date": "2022-06-29",
+                "end_date": "2024-12-29",
+                "organisation": org_data,
+                "country_code": "RU",
+                "restrictions": restrictions,
+                "goods": goods,
+            },
+        )
+
+        self.test_file = Path("mail/tests/files/icms/icms_chief_licence_data_file_sanction")
         self.assertTrue(self.test_file.is_file())
 
     def test_generate_icms_licence_file(self):

--- a/mail/views.py
+++ b/mail/views.py
@@ -71,6 +71,7 @@ class LicenceDataIngestView(APIView):
                 LicenceTypeEnum.IMPORT_OIL: icms_serializers.FirearmOilLicenceDataSerializer,
                 LicenceTypeEnum.IMPORT_DFL: icms_serializers.FirearmDflLicenceDataSerializer,
                 LicenceTypeEnum.IMPORT_SIL: icms_serializers.FirearmSilLicenceDataSerializer,
+                LicenceTypeEnum.IMPORT_SAN: icms_serializers.SanctionLicenceDataSerializer,
             }
 
             return serializers[app_type]


### PR DESCRIPTION
Changes:
  - Update LicenceDataIngestView to support SAN licences.
  - Add serializer for SAN licences.
  - Update ICMS edifact converter to support SAN licences.
  - Add enum to define CHIEF controlled by values.
  - Add enum to define CHIEF quantity code values.