### PR TITLE
Separate out authentication from mail server

### DIFF
--- a/mail/auth.py
+++ b/mail/auth.py
@@ -1,0 +1,23 @@
+import poplib
+
+from typing_extensions import Protocol
+
+
+class Authenticator(Protocol):
+    user: str
+
+    def authenticate(self, connection: poplib.POP3_SSL):
+        ...
+
+
+class BasicAuthentication:
+    def __init__(self, user: str, password: str):
+        self.user = user
+        self.password = password
+
+    def authenticate(self, connection: poplib.POP3_SSL):
+        connection.user(self.user)
+        connection.pass_(self.password)
+
+    def __eq__(self, other: Authenticator):
+        return self.user == other.user and self.password == other.password

--- a/mail/tests/test_auth.py
+++ b/mail/tests/test_auth.py
@@ -1,0 +1,29 @@
+from poplib import POP3_SSL
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+
+from mail.auth import BasicAuthentication
+
+
+class BasicAuthenticationTests(SimpleTestCase):
+    def test_authenticates_connection(self):
+        pop3conn = MagicMock(spec=POP3_SSL)
+        mock_conn = pop3conn()
+
+        auth = BasicAuthentication("user", "password")
+        auth.authenticate(mock_conn)
+        mock_conn.user.assert_called_with("user")
+        mock_conn.pass_.assert_called_with("password")
+
+    def test_equal(self):
+        auth = BasicAuthentication("user", "password")
+        equal_auth = BasicAuthentication("user", "password")
+
+        self.assertEqual(auth, equal_auth)
+
+    def test_not_equal(self):
+        auth = BasicAuthentication("user", "password")
+        equal_auth = BasicAuthentication("diff_user", "diff_password")
+
+        self.assertNotEqual(auth, equal_auth)


### PR DESCRIPTION
This change is in preparation for when we add OAuth authentication, this separates out the concerns for authenticating the connection and allows us to swap out authentication on a case by case basis if necessary