### PR TITLE
Upgrade python buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,5 @@
-
----
 applications:
-  - name: lite-hmrc-dev
-    buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.30
+  - buildpacks:
+      - python_buildpack
     memory: 256M
     disk_quota: 512M


### PR DESCRIPTION
When deploying the latest changes for https://github.com/uktrade/lite-hmrc/pull/158 there was a failure when installing the new requirements (sub-dependencies from `msal`, more specifically `cryptography`).

Updating the buildpack has rectified the issues with installing the dependencies.