### PR TITLE
Add logging for failures to ingest licence data

### DIFF
--- a/mail/views.py
+++ b/mail/views.py
@@ -28,7 +28,11 @@ class LicenceDataIngestView(APIView):
             data = request.data["licence"]
         except KeyError:
             errors = [{"licence": "This field is required."}]
-
+            logger.error(
+                "Failed to create licence data for %s due to %s",
+                request.data,
+                errors,
+            )
             return JsonResponse(status=status.HTTP_400_BAD_REQUEST, data={"errors": errors})
 
         serializer_cls = self.get_serializer_cls(data["type"])
@@ -36,6 +40,11 @@ class LicenceDataIngestView(APIView):
 
         if not serializer.is_valid():
             errors = [{"licence": serializer.errors}]
+            logger.error(
+                "Failed to create licence data for %s due to %s",
+                data,
+                errors,
+            )
             return JsonResponse(status=status.HTTP_400_BAD_REQUEST, data={"errors": errors})
 
         if data["action"] == LicenceActionEnum.UPDATE:


### PR DESCRIPTION
We have a licence that appears to be failing to be created, however we respond with a 400 and the sender doesn't seem to throw any logs to indicate when this has happened. We also don't get the full response back in our logs when we send this back so we don't really know what's causing this problem.

This adds logging so that we're aware of any failures when creating licence data.