### PR TITLE
LTD-3148-fix-trader-address-multiline 

### DIFF
--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -248,7 +248,7 @@ def sanitize_foreign_trader_address(trader):
 
 def sanitize_trader_address(trader):
     """
-    Foreign trader address is split into 5 lines.
+    Trader address is split into 5 lines.
     When any since one of these lines exceed 35 chars we need to break then up into lines
     There is a possibility of truncating the address here if this happens we log it
     """

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -79,7 +79,7 @@ def generate_lines_for_licence(licence: LicencePayload) -> Iterable[chieftypes._
 
     if licence.action != LicenceActionEnum.CANCEL:
         trader = payload.get("organisation")
-        trader = sanitize_foreign_trader_address(trader)
+        trader = sanitize_trader_address(trader)
 
         yield chieftypes.Trader(
             rpa_trader_id=trader.get("eori_number", ""),
@@ -239,6 +239,35 @@ def sanitize_foreign_trader_address(trader):
     addr_lines = textwrap.wrap(addr_line, width=FOREIGN_TRADER_ADDR_LINE_MAX_LEN, break_long_words=False)
     if len(addr_lines) > FOREIGN_TRADER_NUM_ADDR_LINES:
         addr_lines = addr_lines[:FOREIGN_TRADER_NUM_ADDR_LINES]
+
+    for index, line in enumerate(addr_lines, start=1):
+        address[f"line_{index}"] = line
+
+    return trader
+
+
+def sanitize_trader_address(trader):
+    """
+    Foreign trader address is split into 5 lines.
+    When any since one of these lines exceed 35 chars we need to break then up into lines
+    There is a possibility of truncating the address here if this happens we log it
+    """
+    address = trader["address"]
+
+    addr_line = " ".join(address.get(f"line_{i+1}") for i in range(5) if address.get(f"line_{i+1}"))
+
+    addr_line = addr_line.replace("\n", " ").replace("\r", " ")
+    # replace special characters
+    addr_line = addr_line.replace("#", "")
+    addr_lines = textwrap.wrap(addr_line, width=FOREIGN_TRADER_ADDR_LINE_MAX_LEN, break_long_words=False)
+    if len(addr_lines) > FOREIGN_TRADER_NUM_ADDR_LINES:
+        addr_lines = addr_lines[:FOREIGN_TRADER_NUM_ADDR_LINES]
+        logging.info(
+            "Truncating trader address as we exceeded %d, original_address: %s, truncated_address: %s",
+            FOREIGN_TRADER_ADDR_LINE_MAX_LEN,
+            addr_line,
+            addr_lines,
+        )
 
     for index, line in enumerate(addr_lines, start=1):
         address[f"line_{index}"] = line

--- a/mail/tests/test_end_to_end.py
+++ b/mail/tests/test_end_to_end.py
@@ -37,7 +37,7 @@ class EndToEndTests(LiteHMRCTestClient):
         run_number = body.split("\n")[0].split("\\")[6]
         expected_mail_body = rf"""1\fileHeader\SPIRE\CHIEF\licenceData\{ymdhm_timestamp}\{run_number}\N
 2\licence\20200000001P\insert\GBSIEL/2020/0000001/P\SIE\E\20200602\20220602
-3\trader\\GB123456789000\20200602\20220602\Organisation\might\248 James Key Apt. 515\Apt. 942\West Ashleyton\Farnborough\GU40 2LX
+3\trader\\GB123456789000\20200602\20220602\Organisation\might 248 James Key Apt. 515 Apt.\942 West Ashleyton Farnborough\Apt. 942\West Ashleyton\Farnborough\GU40 2LX
 4\country\GB\\D
 5\foreignTrader\End User\42 Road, London, Buckinghamshire\\\\\\GB
 6\restrictions\Provisos may apply please see licence

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -42,7 +42,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             + "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
             + "\\1234\\N"
             + "\n2\\licence\\20200000001P\\insert\\GBSIEL/2020/0000001/P\\SIE\\E\\20200602\\20220602"
-            + f"\n3\\trader\\\\{trader['eori_number']}\\20200602\\20220602\\Organisation\\might\\248 James Key Apt. 515\\Apt. 942\\West Ashleyton\\Farnborough\\GU40 2LX"
+            + f"\n3\\trader\\\\{trader['eori_number']}\\20200602\\20220602\\Organisation\\might 248 James Key Apt. 515 Apt.\\942 West Ashleyton Farnborough\\Apt. 942\\West Ashleyton\\Farnborough\\GU40 2LX"
             + "\n4\\country\\GB\\\\D"
             + "\n5\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
             + "\n6\\restrictions\\Provisos may apply please see licence"
@@ -103,7 +103,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             + "\n2\\licence\\20200000001P\\cancel\\GBSIEL/2020/0000001/P\\SIE\\E\\20200602\\20220602"
             + "\n3\\end\\licence\\2"
             + "\n4\\licence\\20200000001Pa\\insert\\GBSIEL/2020/0000001/P/a\\SIE\\E\\20200602\\20220703"
-            + f"\n5\\trader\\\\{trader['eori_number']}\\20200602\\20220703\\Organisation\\might\\248 James Key Apt. 515\\Apt. 942\\West Ashleyton\\Farnborough\\GU40 2LX"
+            + f"\n5\\trader\\\\{trader['eori_number']}\\20200602\\20220703\\Organisation\\might 248 James Key Apt. 515 Apt.\\942 West Ashleyton Farnborough\\Apt. 942\\West Ashleyton\\Farnborough\\GU40 2LX"
             + "\n6\\country\\GB\\\\D"
             + "\n7\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
             + "\n8\\restrictions\\Provisos may apply please see licence"
@@ -173,6 +173,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
         )
         licences = LicencePayload.objects.filter(is_processed=False)
         edifact_file = licences_to_edifact(licences, 1234, "FOO")
+
         foreign_trader_line = edifact_file.split("\n")[4]
         self.assertEqual(foreign_trader_line, expected_trader_line)
 
@@ -184,7 +185,31 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
                 "NEW TESCO LANE",
                 "HARROW",
                 "MIDDLESEX",
-                "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\TEST12345 IFailedTooLong Ltd -\\Registered address\\NEW TESCO LANE\\HARROW\\MIDDLESEX\\GU40 2LX",
+                "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\TEST12345 IFailedTooLong Ltd -\\Registered address BIGMAM MANOR NEW\\TESCO LANE HARROW MIDDLESEX\\HARROW\\MIDDLESEX\\GU40 2LX",
+            ),
+            (
+                "TEST12345",
+                "BIGMAM MANOR IFailedTooLong Ltd - Registered address",
+                "NEW TESCO LANE",
+                "HARROW",
+                "MIDDLESEX",
+                "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\TEST12345 BIGMAM MANOR\\IFailedTooLong Ltd - Registered\\address NEW TESCO LANE HARROW\\MIDDLESEX\\MIDDLESEX\\GU40 2LX",
+            ),
+            (
+                "TEST12345",
+                "BIGMAM MANOR",
+                "NEW TESCO LANE - IFailedTooLong Ltd - Registered address",
+                "HARROW",
+                "MIDDLESEX",
+                "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\TEST12345 BIGMAM MANOR NEW TESCO\\LANE - IFailedTooLong Ltd -\\Registered address HARROW MIDDLESEX\\HARROW\\MIDDLESEX\\GU40 2LX",
+            ),
+            (
+                "TEST12345 - IFailedTooLong Ltd - Registered address",
+                "BIGMAM MANOR - IFailedTooLong Ltd - Registered address",
+                "NEW TESCO LANE - IFailedTooLong Ltd - Registered address",
+                "HARROW - IFailedTooLong Ltd - Registered address",
+                "MIDDLESEX - IFailedTooLong Ltd - Registered address",
+                "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\TEST12345 - IFailedTooLong Ltd -\\Registered address BIGMAM MANOR -\\IFailedTooLong Ltd - Registered\\address NEW TESCO LANE -\\IFailedTooLong Ltd - Registered\\GU40 2LX",
             ),
             (
                 "this is short address",
@@ -192,7 +217,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
                 "NEW TESCO LANE",
                 "HARROW",
                 "MIDDLESEX",
-                "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\this is short address\\BIGMAM MANOR\\NEW TESCO LANE\\HARROW\\MIDDLESEX\\GU40 2LX",
+                "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\this is short address BIGMAM MANOR\\NEW TESCO LANE HARROW MIDDLESEX\\NEW TESCO LANE\\HARROW\\MIDDLESEX\\GU40 2LX",
             ),
         ]
     )


### PR DESCRIPTION
Initial fix was to also sanitise  the trade address key under [“organisation”] however this fix failed since more than 1 line was going over the 35 charter limit. Since a trader address is split over 5 lines. We have now created a new function which combines the 5 lines and then splits into 35 chars this has a couple of implications :

Trader address format gets changes 

We truncate if we exceed 5 lines

For the later we log in sentry this is the safe fix for now . Long term we should restrict UI from going over.