### PR TITLE
 LTD-3198-Queue-healthcheck 

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -130,6 +130,7 @@ LITE_LICENCE_DATA_POLL_INTERVAL = env.int("LITE_LICENCE_DATA_POLL_INTERVAL", def
 EMAIL_AWAITING_REPLY_TIME = env.int("EMAIL_AWAITING_REPLY_TIME", default=3600)
 EMAIL_AWAITING_CORRECTIONS_TIME = env.int("EMAIL_AWAITING_CORRECTIONS_TIME", default=3600)
 NOTIFY_USERS = env.json("NOTIFY_USERS", default=[])
+LICENSE_POLL_INTERVAL = env.int("LICENSE_POLL_INTERVAL", default=300)
 
 # Password validation
 # https://docs.djangoproject.com/en/2.1/ref/settings/#auth-password-validators

--- a/conf/tests/test_healthcheck.py
+++ b/conf/tests/test_healthcheck.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import timedelta
 
 from background_task.models import Task
@@ -7,8 +8,8 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
 
-from mail.enums import ReceptionStatusEnum, ReplyStatusEnum
-from mail.models import Mail
+from mail.enums import LicenceActionEnum, ReceptionStatusEnum, ReplyStatusEnum
+from mail.models import LicencePayload, Mail
 from mail.tasks import LICENCE_DATA_TASK_QUEUE, MANAGE_INBOX_TASK_QUEUE
 
 
@@ -30,20 +31,20 @@ class TestHealthcheck(testcases.TestCase):
             sent_at=sent_at,
         )
         response = self.client.get(self.url)
-        self.assertEqual(response.context["message"], "not OK")
+        self.assertEqual(response.context["message"], "Pending mail error")
         self.assertEqual(response.context["status"], status.HTTP_503_SERVICE_UNAVAILABLE)
 
-    def test_healthcheck_service_unavailable_rejected_mail(self):
-        sent_at = timezone.now() - timedelta(seconds=settings.EMAIL_AWAITING_CORRECTIONS_TIME)
-        Mail.objects.create(
-            edi_filename="filename",
-            edi_data="1\\fileHeader\\CHIEF\\SPIRE\\",
-            response_data="1\\line1\\rejected\\",
-            status=ReceptionStatusEnum.REPLY_SENT,
-            sent_at=sent_at,
+    def test_healthcheck_service_unavailable_pending_payload(self):
+        received_at = timezone.now() - timedelta(seconds=settings.LICENSE_POLL_INTERVAL)
+        LicencePayload.objects.create(
+            lite_id=uuid.uuid4(),
+            reference="ABC12345",
+            action=LicenceActionEnum.INSERT,
+            is_processed=False,
+            received_at=received_at,
         )
         response = self.client.get(self.url)
-        self.assertEqual(response.context["message"], "not OK")
+        self.assertEqual(response.context["message"], "Payload objects error")
         self.assertEqual(response.context["status"], status.HTTP_503_SERVICE_UNAVAILABLE)
 
     def test_healthcheck_service_unavailable_inbox_task_not_responsive(self):
@@ -52,7 +53,7 @@ class TestHealthcheck(testcases.TestCase):
         task.run_at = run_at
         task.save()
         response = self.client.get(self.url)
-        self.assertEqual(response.context["message"], "not OK")
+        self.assertEqual(response.context["message"], "manage_inbox_queue error")
         self.assertEqual(response.context["status"], status.HTTP_503_SERVICE_UNAVAILABLE)
 
     def test_healthcheck_service_unavailable_licence_update_task_not_responsive(self):
@@ -61,5 +62,5 @@ class TestHealthcheck(testcases.TestCase):
         task.run_at = run_at
         task.save()
         response = self.client.get(self.url)
-        self.assertEqual(response.context["message"], "not OK")
+        self.assertEqual(response.context["message"], "licences_updates_queue error")
         self.assertEqual(response.context["status"], status.HTTP_503_SERVICE_UNAVAILABLE)

--- a/conf/views.py
+++ b/conf/views.py
@@ -10,11 +10,17 @@ from rest_framework.status import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 from rest_framework.views import APIView
 
 from mail.enums import ChiefSystemEnum, ReceptionStatusEnum, ReplyStatusEnum
-from mail.models import Mail
+from mail.models import LicencePayload, Mail
 from mail.tasks import LICENCE_DATA_TASK_QUEUE, MANAGE_INBOX_TASK_QUEUE
 
 
 class HealthCheck(APIView):
+    ERROR_LICENCE_DATA_TASK_QUEUE = "licences_updates_queue error"
+    ERROR_MANAGE_INBOX_TASK_QUEUE = "manage_inbox_queue error"
+    ERROR_PENDING_MAIL = "Pending mail error"
+    ERROR_REJECTED_MAIL = "Rejected mail error"
+    ERROR_PAYLOAD_OBJECTS = "Payload objects error"
+
     def get(self, request):
         """
         Provides a health check endpoint as per [https://man.uktrade.io/docs/howtos/healthcheck.html#pingdom]
@@ -22,13 +28,14 @@ class HealthCheck(APIView):
 
         start_time = time.time()
 
-        if not self._is_lite_licence_update_task_responsive():
-            logging.error("%s is not responsive", LICENCE_DATA_TASK_QUEUE)
-            return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, "not OK", start_time)
-
-        if settings.CHIEF_SOURCE_SYSTEM == ChiefSystemEnum.SPIRE and not self._is_inbox_polling_task_responsive():
-            logging.error("%s is not responsive", MANAGE_INBOX_TASK_QUEUE)
-            return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, "not OK", start_time)
+        payload_object_pending = self._get_license_payload_object_pending()
+        if payload_object_pending:
+            logging.error(
+                "Payload object has been unprocessed for over %s seconds: %s",
+                settings.LICENSE_POLL_INTERVAL,
+                payload_object_pending,
+            )
+            return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, self.ERROR_PAYLOAD_OBJECTS, start_time)
 
         pending_mail = self._get_pending_mail()
         if pending_mail:
@@ -37,16 +44,15 @@ class HealthCheck(APIView):
                 settings.EMAIL_AWAITING_REPLY_TIME,
                 pending_mail,
             )
-            return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, "not OK", start_time)
+            return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, self.ERROR_PENDING_MAIL, start_time)
 
-        rejected_mail = self._get_rejected_mail()
-        if rejected_mail:
-            logging.error(
-                "The following Mail has been rejected for over %s seconds: %s",
-                settings.EMAIL_AWAITING_CORRECTIONS_TIME,
-                rejected_mail,
-            )
-            return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, "not OK", start_time)
+        if not self._is_lite_licence_update_task_responsive():
+            logging.error("%s is not responsive", LICENCE_DATA_TASK_QUEUE)
+            return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, self.ERROR_LICENCE_DATA_TASK_QUEUE, start_time)
+
+        if settings.CHIEF_SOURCE_SYSTEM == ChiefSystemEnum.SPIRE and not self._is_inbox_polling_task_responsive():
+            logging.error("%s is not responsive", MANAGE_INBOX_TASK_QUEUE)
+            return self._build_response(HTTP_503_SERVICE_UNAVAILABLE, self.ERROR_MANAGE_INBOX_TASK_QUEUE, start_time)
 
         logging.info("All services are responsive")
         return self._build_response(HTTP_200_OK, "OK", start_time)
@@ -88,3 +94,9 @@ class HealthCheck(APIView):
         context = {"message": message, "response_time": response_time, "status": status}
 
         return render(self.request, "healthcheck.xml", context, content_type="application/xml", status=status)
+
+    @staticmethod
+    def _get_license_payload_object_pending() -> bool:
+        dt = timezone.now() + datetime.timedelta(seconds=settings.LICENSE_POLL_INTERVAL)
+
+        return LicencePayload.objects.filter(is_processed=False, received_at__lte=dt).first()


### PR DESCRIPTION
This is to add an additional health check when we get payload objects packing up. This can happen when either tasks aren't running or we have a failure. 

Also I have removed the rejected mail responses health check since we don't have an action for these anyway and it doesn't black the Q. 