### PR TITLE
Add MIR to UnitMapping for lite serializer

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -193,6 +193,7 @@ class UnitMapping(enum.Enum):
     MTR = 57  # meters
     LTR = 94  # litre
     MTQ = 2  # meters_cubed
+    MIR = 74  # millilitre
     ITG = 30  # intangible
 
     @classmethod

--- a/mail/tests/test_enums.py
+++ b/mail/tests/test_enums.py
@@ -26,6 +26,6 @@ class UnitMappingTests(unittest.TestCase):
 
     def test_serializer_choices(self):
         choices = UnitMapping.serializer_choices()
-        expected = ["NAR", "GRM", "KGM", "MTK", "MTR", "LTR", "MTQ", "ITG"]
+        expected = ["NAR", "GRM", "KGM", "MTK", "MTR", "LTR", "MTQ", "MIR", "ITG"]
 
         self.assertEqual(choices, expected)


### PR DESCRIPTION
This is a fix for an error observed in Sentry when creating license data from lite, as a good has `MIR` as the unit in the request body from lite-api, and this is not supported by the lite-hmrc lite good serializer. This changes the UnitMapping to include the `MIR` unit with the appropriate code as in the UK Trade Tariff list (https://www.gov.uk/government/publications/uk-trade-tariff-quantity-codes/uk-trade-tariff-quantity-codes)