### PR TITLE
Ltd 4311 cflinuxfs4

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,4 +3,4 @@ applications:
       - python_buildpack
     memory: 256M
     disk_quota: 512M
-    stack: cflinuxfs3
+    stack: cflinuxfs4


### PR DESCRIPTION
This explicitly sets the version for the cf stack in preparation for the cflinuxfs4 upgrade.

This is currently the implicit version but once we upgrade the stack version these change becomes "sticky" and means that even if we try to rollback we can still be stuck with this new version, if this is set explicitly then if we need to rollback it will rollback to this specific version.