### PR TITLE
Ltd-4583: Migrate the task that notifies rejected licences to use Celery

### DIFF
--- a/mail/celery_tasks.py
+++ b/mail/celery_tasks.py
@@ -1,0 +1,46 @@
+import logging
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from celery import shared_task
+from django.conf import settings
+
+from mail.servers import smtp_send
+
+logger = logging.getLogger(__name__)
+
+MAX_ATTEMPTS = 3
+RETRY_BACKOFF = 180
+
+
+# Notify Users of Rejected Mail
+@shared_task(
+    autoretry_for=(Exception,),
+    max_retries=MAX_ATTEMPTS,
+    retry_backoff=RETRY_BACKOFF,
+)
+def notify_users_of_rejected_mail(mail_id, mail_response_date):
+    """If a rejected email is found, this task notifies users of the rejection"""
+
+    logger.info("Notifying users of rejected Mail [%s, %s]", mail_id, mail_response_date)
+
+    try:
+        multipart_msg = MIMEMultipart()
+        multipart_msg["From"] = settings.EMAIL_USER
+        multipart_msg["To"] = ",".join(settings.NOTIFY_USERS)
+        multipart_msg["Subject"] = "Mail rejected"
+        body = MIMEText(f"Mail [{mail_id}] received at [{mail_response_date}] was rejected")
+        multipart_msg.attach(body)
+
+        smtp_send(multipart_msg)
+    except Exception as exc:  # noqa
+        error_message = (
+            f"An unexpected error occurred when notifying users of rejected Mail "
+            f"[{mail_id}, {mail_response_date}] -> {type(exc).__name__}: {exc}"
+        )
+
+        # Raise an exception
+        # this will cause the task to be marked as 'Failed' and retried if there are retry attempts left
+        raise Exception(error_message)
+    else:
+        logger.info("Successfully notified users of rejected Mail [%s, %s]", mail_id, mail_response_date)

--- a/mail/celery_tasks.py
+++ b/mail/celery_tasks.py
@@ -1,13 +1,12 @@
-import logging
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from django.conf import settings
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from celery import shared_task
-from django.conf import settings
-
 from mail.servers import smtp_send
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 MAX_ATTEMPTS = 3
 RETRY_BACKOFF = 180
@@ -19,28 +18,28 @@ RETRY_BACKOFF = 180
     max_retries=MAX_ATTEMPTS,
     retry_backoff=RETRY_BACKOFF,
 )
-def notify_users_of_rejected_mail(mail_id, mail_response_date):
-    """If a rejected email is found, this task notifies users of the rejection"""
+def notify_users_of_rejected_mail(mail_id, mail_response_subject):
+    """If a reply is received with rejected licences this task notifies users of the rejection"""
 
-    logger.info("Notifying users of rejected Mail [%s, %s]", mail_id, mail_response_date)
+    logger.info("Notifying users of rejected licences found in mail with subject %s", mail_response_subject)
 
     try:
         multipart_msg = MIMEMultipart()
         multipart_msg["From"] = settings.EMAIL_USER
         multipart_msg["To"] = ",".join(settings.NOTIFY_USERS)
         multipart_msg["Subject"] = "Mail rejected"
-        body = MIMEText(f"Mail [{mail_id}] received at [{mail_response_date}] was rejected")
+        body = MIMEText(f"Mail [{mail_id}] with subject [{mail_response_subject}] has rejected licences")
         multipart_msg.attach(body)
 
         smtp_send(multipart_msg)
     except Exception as exc:  # noqa
         error_message = (
-            f"An unexpected error occurred when notifying users of rejected Mail "
-            f"[{mail_id}, {mail_response_date}] -> {type(exc).__name__}: {exc}"
+            f"An unexpected error occurred when notifying users of rejected licences "
+            f"[Id: {mail_id}, subject: {mail_response_subject}] -> {type(exc).__name__}: {exc}"
         )
 
         # Raise an exception
         # this will cause the task to be marked as 'Failed' and retried if there are retry attempts left
-        raise Exception(error_message)
-    else:
-        logger.info("Successfully notified users of rejected Mail [%s, %s]", mail_id, mail_response_date)
+        raise exc(error_message)
+
+    logger.info("Successfully notified users of rejected licences found in mail with subject %s", mail_response_subject)

--- a/mail/celery_tasks.py
+++ b/mail/celery_tasks.py
@@ -3,6 +3,7 @@ from celery.utils.log import get_task_logger
 from django.conf import settings
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from smtplib import SMTPException
 
 from mail.servers import smtp_send
 
@@ -14,7 +15,7 @@ RETRY_BACKOFF = 180
 
 # Notify Users of Rejected Mail
 @shared_task(
-    autoretry_for=(Exception,),
+    autoretry_for=(SMTPException,),
     max_retries=MAX_ATTEMPTS,
     retry_backoff=RETRY_BACKOFF,
 )
@@ -32,7 +33,7 @@ def notify_users_of_rejected_mail(mail_id, mail_response_subject):
         multipart_msg.attach(body)
 
         smtp_send(multipart_msg)
-    except Exception as exc:  # noqa
+    except SMTPException as exc:  # noqa
         error_message = (
             f"An unexpected error occurred when notifying users of rejected licences "
             f"[Id: {mail_id}, subject: {mail_response_subject}] -> {type(exc).__name__}: {exc}"

--- a/mail/celery_tasks.py
+++ b/mail/celery_tasks.py
@@ -29,7 +29,7 @@ def notify_users_of_rejected_mail(mail_id, mail_response_subject):
         multipart_msg["From"] = settings.EMAIL_USER
         multipart_msg["To"] = ",".join(settings.NOTIFY_USERS)
         multipart_msg["Subject"] = "Mail rejected"
-        body = MIMEText(f"Mail [{mail_id}] with subject [{mail_response_subject}] has rejected licences")
+        body = MIMEText(f"Mail (Id: {mail_id}) with subject {mail_response_subject} has rejected licences")
         multipart_msg.attach(body)
 
         smtp_send(multipart_msg)

--- a/mail/models.py
+++ b/mail/models.py
@@ -7,6 +7,7 @@ from typing import List
 from django.conf import settings
 from django.db import IntegrityError, models
 from django.utils import timezone
+from mail.celery_tasks import notify_users_of_rejected_licences
 from model_utils.models import TimeStampedModel
 
 from mail.enums import (
@@ -94,9 +95,7 @@ class Mail(models.Model):
 
     @staticmethod
     def notify_users(id, response_subject):
-        from mail.celery_tasks import notify_users_of_rejected_mail
-
-        notify_users_of_rejected_mail.delay(str(id), response_subject)
+        notify_users_of_rejected_licences.delay(str(id), response_subject)
 
 
 class LicenceData(models.Model):

--- a/mail/models.py
+++ b/mail/models.py
@@ -94,9 +94,9 @@ class Mail(models.Model):
 
     @staticmethod
     def notify_users(id, response_date):
-        from mail.tasks import notify_users_of_rejected_mail
+        from mail.celery_tasks import notify_users_of_rejected_mail
 
-        notify_users_of_rejected_mail(str(id), str(response_date))
+        notify_users_of_rejected_mail.delay(str(id), str(response_date))
 
 
 class LicenceData(models.Model):

--- a/mail/models.py
+++ b/mail/models.py
@@ -78,7 +78,7 @@ class Mail(models.Model):
 
         if settings.SEND_REJECTED_EMAIL:
             if self.response_data and ReplyStatusEnum.REJECTED in self.response_data:
-                self.notify_users(self.id, self.response_date)
+                self.notify_users(self.id, self.response_subject)
 
     def set_locking_time(self, offset: int = 0):
         self.currently_processing_at = timezone.now() + timedelta(seconds=offset)
@@ -93,10 +93,10 @@ class Mail(models.Model):
         self.save()
 
     @staticmethod
-    def notify_users(id, response_date):
+    def notify_users(id, response_subject):
         from mail.celery_tasks import notify_users_of_rejected_mail
 
-        notify_users_of_rejected_mail.delay(str(id), str(response_date))
+        notify_users_of_rejected_mail.delay(str(id), response_subject)
 
 
 class LicenceData(models.Model):

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -2,8 +2,6 @@ import logging
 import os
 import urllib.parse
 from datetime import timedelta
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 from typing import List, MutableMapping, Tuple
 
 from background_task import background
@@ -21,7 +19,6 @@ from mail.libraries.lite_to_edifact_converter import EdifactValidationError
 from mail.libraries.routing_controller import check_and_route_emails, send, update_mail
 from mail.libraries.usage_data_decomposition import build_json_payload_from_data_blocks, split_edi_data_by_id
 from mail.models import LicenceIdMapping, LicencePayload, Mail, UsageData
-from mail.servers import smtp_send
 
 logger = logging.getLogger(__name__)
 
@@ -252,38 +249,7 @@ def send_licence_data_to_hmrc():
         return True
 
 
-# Notify Users of Rejected Mail
-@background(queue=NOTIFY_USERS_TASK_QUEUE, schedule=0)
-def notify_users_of_rejected_mail(mail_id, mail_response_date):
-    """If a rejected email is found, this task notifies users of the rejection"""
-
-    logger.info("Notifying users of rejected Mail [%s, %s]", mail_id, mail_response_date)
-
-    try:
-        multipart_msg = MIMEMultipart()
-        multipart_msg["From"] = settings.EMAIL_USER
-        multipart_msg["To"] = ",".join(settings.NOTIFY_USERS)
-        multipart_msg["Subject"] = "Mail rejected"
-        body = MIMEText(f"Mail [{mail_id}] received at [{mail_response_date}] was rejected")
-        multipart_msg.attach(body)
-
-        smtp_send(multipart_msg)
-    except Exception as exc:  # noqa
-        error_message = (
-            f"An unexpected error occurred when notifying users of rejected Mail "
-            f"[{mail_id}, {mail_response_date}] -> {type(exc).__name__}: {exc}"
-        )
-
-        # Raise an exception
-        # this will cause the task to be marked as 'Failed' and retried if there are retry attempts left
-        raise Exception(error_message)
-    else:
-        logger.info("Successfully notified users of rejected Mail [%s, %s]", mail_id, mail_response_date)
-
-
 # Manage Inbox
-
-
 @background(queue=MANAGE_INBOX_TASK_QUEUE, schedule=0)
 def manage_inbox():
     """Main task which scans inbox for SPIRE and HMRC emails"""

--- a/mail/test_celery_task.py
+++ b/mail/test_celery_task.py
@@ -1,0 +1,34 @@
+import email.mime.multipart
+from unittest import mock
+
+from django.test import TestCase
+
+from mail.celery_tasks import notify_users_of_rejected_mail
+
+
+class NotifyUsersOfRejectedMailTests(TestCase):
+    @mock.patch("smtplib.SMTP.send_message")
+    def test_send_success(self, mock_send):
+        settings = {
+            "EMAIL_USER": "test@example.com",  # /PS-IGNORE
+            "NOTIFY_USERS": ["notify@example.com"],  # /PS-IGNORE
+        }
+        with self.settings(**settings):
+            notify_users_of_rejected_mail.delay("123", "1999-12-31 23:45:59")
+
+        self.assertEqual(len(mock_send.delay.call_args_list), 1)
+        message = mock_send.call_args[0][0]
+        self.assertIsInstance(message, email.mime.multipart.MIMEMultipart)
+
+        expected_headers = {
+            "Content-Type": "multipart/mixed",
+            "MIME-Version": "1.0",
+            "From": "test@example.com",  # /PS-IGNORE
+            "To": "notify@example.com",  # /PS-IGNORE
+            "Subject": "Mail rejected",
+        }
+        self.assertDictEqual(dict(message), expected_headers)
+
+        text_payload = message.get_payload(0)
+        expected_body = "Mail [123] received at [1999-12-31 23:45:59] was rejected"
+        self.assertEqual(text_payload.get_payload(), expected_body)

--- a/mail/test_celery_task.py
+++ b/mail/test_celery_task.py
@@ -14,7 +14,7 @@ class NotifyUsersOfRejectedMailTests(TestCase):
             "NOTIFY_USERS": ["notify@example.com"],  # /PS-IGNORE
         }
         with self.settings(**settings):
-            notify_users_of_rejected_mail("123", "1999-12-31 23:45:59")
+            notify_users_of_rejected_mail("123", "CHIEF_SPIRE_licenceReply_202401180900_42557")
 
         mock_send.assert_called_once()
 
@@ -32,5 +32,5 @@ class NotifyUsersOfRejectedMailTests(TestCase):
         self.assertDictEqual(dict(message), expected_headers)
 
         text_payload = message.get_payload(0)
-        expected_body = "Mail [123] received at [1999-12-31 23:45:59] was rejected"
+        expected_body = "Mail (Id: 123) with subject CHIEF_SPIRE_licenceReply_202401180900_42557 has rejected licences"
         self.assertEqual(text_payload.get_payload(), expected_body)

--- a/mail/test_celery_task.py
+++ b/mail/test_celery_task.py
@@ -7,16 +7,18 @@ from mail.celery_tasks import notify_users_of_rejected_mail
 
 
 class NotifyUsersOfRejectedMailTests(TestCase):
-    @mock.patch("smtplib.SMTP.send_message")
+    @mock.patch("mail.celery_tasks.smtp_send")
     def test_send_success(self, mock_send):
         settings = {
             "EMAIL_USER": "test@example.com",  # /PS-IGNORE
             "NOTIFY_USERS": ["notify@example.com"],  # /PS-IGNORE
         }
         with self.settings(**settings):
-            notify_users_of_rejected_mail.delay("123", "1999-12-31 23:45:59")
+            notify_users_of_rejected_mail("123", "1999-12-31 23:45:59")
 
-        self.assertEqual(len(mock_send.delay.call_args_list), 1)
+        mock_send.assert_called_once()
+
+        self.assertEqual(len(mock_send.call_args_list), 1)
         message = mock_send.call_args[0][0]
         self.assertIsInstance(message, email.mime.multipart.MIMEMultipart)
 

--- a/mail/tests/conftest.py
+++ b/mail/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def celery_sync(settings):
+    settings.CELERY_TASK_ALWAYS_EAGER = True

--- a/mail/tests/test_celery_task.py
+++ b/mail/tests/test_celery_task.py
@@ -1,20 +1,16 @@
 import email.mime.multipart
 from unittest import mock
 
-from django.test import TestCase
+from django.test import override_settings, TestCase
 
-from mail.celery_tasks import notify_users_of_rejected_mail
+from mail.celery_tasks import notify_users_of_rejected_licences
 
 
 class NotifyUsersOfRejectedMailTests(TestCase):
+    @override_settings(EMAIL_USER="test@example.com", NOTIFY_USERS=["notify@example.com"])
     @mock.patch("mail.celery_tasks.smtp_send")
     def test_send_success(self, mock_send):
-        settings = {
-            "EMAIL_USER": "test@example.com",  # /PS-IGNORE
-            "NOTIFY_USERS": ["notify@example.com"],  # /PS-IGNORE
-        }
-        with self.settings(**settings):
-            notify_users_of_rejected_mail("123", "CHIEF_SPIRE_licenceReply_202401180900_42557")
+        notify_users_of_rejected_licences("123", "CHIEF_SPIRE_licenceReply_202401180900_42557")
 
         mock_send.assert_called_once()
 
@@ -27,7 +23,7 @@ class NotifyUsersOfRejectedMailTests(TestCase):
             "MIME-Version": "1.0",
             "From": "test@example.com",  # /PS-IGNORE
             "To": "notify@example.com",  # /PS-IGNORE
-            "Subject": "Mail rejected",
+            "Subject": "Licence rejected by HMRC",
         }
         self.assertDictEqual(dict(message), expected_headers)
 

--- a/mail/tests/test_models.py
+++ b/mail/tests/test_models.py
@@ -32,7 +32,7 @@ class TestSendNotifyEmail:
         self.mail.response_date = timezone.now()
         self.mail.save()
 
-        self.mock_notify_users.assert_called_with(self.mail.id, self.mail.response_date)
+        self.mock_notify_users.assert_called_with(self.mail.id, self.mail.response_filename)
 
     @override_settings(SEND_REJECTED_EMAIL=True)
     def test_notify_users_not_called_when_setting_enabled_but_response_accepted(self):

--- a/mail/tests/test_tasks.py
+++ b/mail/tests/test_tasks.py
@@ -1,9 +1,6 @@
-import email.mime.multipart
-from unittest import mock
-
 from django.test import TestCase
 
-from mail.tasks import get_lite_api_url, notify_users_of_rejected_mail
+from mail.tasks import get_lite_api_url
 
 
 class GetLiteAPIUrlTests(TestCase):
@@ -24,31 +21,3 @@ class GetLiteAPIUrlTests(TestCase):
             result = get_lite_api_url()
 
         self.assertEqual(result, "https://example.com/foo")
-
-
-class NotifyUsersOfRejectedMailTests(TestCase):
-    @mock.patch("smtplib.SMTP.send_message")
-    def test_send_success(self, mock_send):
-        settings = {
-            "EMAIL_USER": "test@example.com",  # /PS-IGNORE
-            "NOTIFY_USERS": ["notify@example.com"],  # /PS-IGNORE
-        }
-        with self.settings(**settings):
-            notify_users_of_rejected_mail.now("123", "1999-12-31 23:45:59")
-
-        self.assertEqual(len(mock_send.call_args_list), 1)
-        message = mock_send.call_args[0][0]
-        self.assertIsInstance(message, email.mime.multipart.MIMEMultipart)
-
-        expected_headers = {
-            "Content-Type": "multipart/mixed",
-            "MIME-Version": "1.0",
-            "From": "test@example.com",  # /PS-IGNORE
-            "To": "notify@example.com",  # /PS-IGNORE
-            "Subject": "Mail rejected",
-        }
-        self.assertDictEqual(dict(message), expected_headers)
-
-        text_payload = message.get_payload(0)
-        expected_body = "Mail [123] received at [1999-12-31 23:45:59] was rejected"
-        self.assertEqual(text_payload.get_payload(), expected_body)


### PR DESCRIPTION
Replaced rejected mail with a celery task and implemeted celery into the task which previously was running without background_tasks, which I believe was an oversight