### PR TITLE
Ensure debug celery tasks are properly registered

### DIFF
--- a/conf/celery.py
+++ b/conf/celery.py
@@ -15,3 +15,4 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load celery_tasks.py modules from all registered Django apps.
 app.autodiscover_tasks(related_name="celery_tasks")
+app.autodiscover_tasks(["core"], related_name="celery_tasks")

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "background_task",
     "mail.apps.MailConfig",
     "healthcheck",
+    "core",
 ]
 
 MIDDLEWARE = [

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -38,7 +38,6 @@ INSTALLED_APPS = [
     "background_task",
     "mail.apps.MailConfig",
     "healthcheck",
-    "core",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Add `core` explicitly to celery config so that the debug celery tasks contained within are properly registered.