### PR TITLE
[LTD-4684] Ensure non critical healthchecks do not result in a failed health check response

### DIFF
--- a/healthcheck/checks.py
+++ b/healthcheck/checks.py
@@ -4,13 +4,12 @@ import poplib
 
 from django.conf import settings
 from django.utils import timezone
-
 from health_check.backends import BaseHealthCheckBackend
 from health_check.exceptions import HealthCheckException
+
 from mail.enums import ReceptionStatusEnum
 from mail.libraries.routing_controller import get_hmrc_to_dit_mailserver, get_spire_to_dit_mailserver
 from mail.models import LicencePayload, Mail
-
 
 logger = logging.getLogger(__name__)
 
@@ -28,35 +27,30 @@ class MailboxAuthenticationHealthCheck(BaseHealthCheckBackend):
             except poplib.error_proto as e:
                 response, *_ = e.args
                 error_message = f"Failed to connect to mailbox: {mailserver.hostname} ({response})"
-                logger.error(error_message)
                 self.add_error(HealthCheckException(error_message))
             finally:
                 mailserver.quit_pop3_connection()
 
 
 class LicencePayloadsHealthCheck(BaseHealthCheckBackend):
+    critical_service = False
+
     def check_status(self):
         dt = timezone.now() + datetime.timedelta(seconds=settings.LICENSE_POLL_INTERVAL)
         unprocessed_payloads = LicencePayload.objects.filter(is_processed=False, received_at__lte=dt)
 
         for unprocessed_payload in unprocessed_payloads:
             error_message = f"Payload object has been unprocessed for over {settings.LICENSE_POLL_INTERVAL} seconds: {unprocessed_payload}"
-            logger.error(error_message)
             self.add_error(HealthCheckException(error_message))
-
-        if unprocessed_payloads.exists():
-            raise HealthCheckException("There are unprocessed licence payloads.")
 
 
 class PendingMailHealthCheck(BaseHealthCheckBackend):
+    critical_service = False
+
     def check_status(self):
         dt = timezone.now() - datetime.timedelta(seconds=settings.EMAIL_AWAITING_REPLY_TIME)
         pending_mails = Mail.objects.exclude(status=ReceptionStatusEnum.REPLY_SENT).filter(sent_at__lte=dt)
 
         for pending_mail in pending_mails:
             error_message = f"The following Mail has been pending for over {settings.EMAIL_AWAITING_REPLY_TIME} seconds: {pending_mail}"
-            logger.error(error_message)
             self.add_error(HealthCheckException(error_message))
-
-        if pending_mails.exists():
-            raise HealthCheckException("There are pending mails unprocessed.")

--- a/healthcheck/tests/test_checks.py
+++ b/healthcheck/tests/test_checks.py
@@ -71,8 +71,9 @@ class MailboxAuthenticationHealthCheckTest(TestCase):
             is_processed=False,
         )
         check = LicencePayloadsHealthCheck()
-        with self.assertRaises(HealthCheckException):
-            check.check_status()
+        check.check_status()
+        assert len(check.errors) == 1
+        assert "Payload object has been unprocessed for over" in check.errors[0].message
 
     def test_all_payloads_processed(self):
         LicencePayload.objects.create(
@@ -95,8 +96,9 @@ class MailboxAuthenticationHealthCheckTest(TestCase):
         )
 
         check = PendingMailHealthCheck()
-        with self.assertRaises(HealthCheckException):
-            check.check_status()
+        check.check_status()
+        assert len(check.errors) == 1
+        assert "The following Mail has been pending for over" in check.errors[0].message
 
     def test_no_unprocessed_pending_mails(self):
         Mail.objects.create(


### PR DESCRIPTION
This change re-instates the separation of critical/non-critical health checks.  Non-critical health checks will still report an error through to sentry, but will not cause our pingdom checks to alert.  This will reduce alerting spam for the team.