### PR TITLE
LTD-4652: Manage concurrent SMTP connections using a lock

### DIFF
--- a/conf/celery.py
+++ b/conf/celery.py
@@ -19,6 +19,8 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks(related_name="celery_tasks")
 app.autodiscover_tasks(["core"], related_name="celery_tasks")
 
+# Also allow messages that are serialized/deserialized using pickle
+app.conf.accept_content = ["json", "pickle"]
 
 # Define any regular scheduled tasks
 

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -280,6 +280,14 @@ if REDIS_BASE_URL:
     CELERY_BROKER_URL = _build_redis_url(REDIS_BASE_URL, REDIS_CELERY_DB, **url_args)
     CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": REDIS_BASE_URL,
+    }
+}
+
 CELERY_TASK_ALWAYS_EAGER = env.bool("CELERY_TASK_ALWAYS_EAGER", False)
 CELERY_TASK_STORE_EAGER_RESULT = env.bool("CELERY_TASK_STORE_EAGER_RESULT", False)
 CELERY_TASK_SEND_SENT_EVENT = env.bool("CELERY_TASK_SEND_SENT_EVENT", True)

--- a/mail/celery_tasks.py
+++ b/mail/celery_tasks.py
@@ -220,11 +220,11 @@ def finalise_sending_lite_licence_details(mail_id, message_dto, licence_payload_
     update_mail(mail, message_dto)
 
     licence_payloads = LicencePayload.objects.filter(id__in=licence_payload_ids, is_processed=False)
-    if licence_payloads:
-        licence_payloads.update(is_processed=True)
+    references = [item.reference for item in licence_payloads]
 
-        references = licence_payloads.values_list("reference", flat=True)
-        logger.info("Licence payloads of references %s marked as processed", references)
+    licence_payloads.update(is_processed=True)
+
+    logger.info("Licence payloads with references %s marked as processed", references)
 
 
 class SendLicenceDetailsBaseTask(Task):

--- a/mail/celery_tasks.py
+++ b/mail/celery_tasks.py
@@ -106,7 +106,7 @@ class SendEmailBaseTask(Task):
         logger.info("Sending email task successful")
 
         email_type, mail_id, message_dto = args
-        if email_type == EmailType.LICENCE_DETAILS:
+        if email_type == EmailType.SPIRE_LICENCE_DETAILS:
             message_dto = EmailMessageDto(*message_dto)
             mail = Mail.objects.get(id=mail_id)
             update_mail(mail, message_dto)
@@ -157,10 +157,10 @@ def send_email_task(email_type, mail_id, message_dto):
         if lock_acquired:
             logger.info("Lock acquired, preparing to send email")
 
-            # de-serialize back to required type
+            # de-serialize back to original type
             message_dto = EmailMessageDto(*message_dto)
 
-            if email_type == EmailType.LICENCE_DETAILS:
+            if email_type == EmailType.SPIRE_LICENCE_DETAILS:
                 message = build_email_message(message_dto)
                 smtp_send(message)
 

--- a/mail/celery_tasks.py
+++ b/mail/celery_tasks.py
@@ -8,7 +8,7 @@ from celery import Task, shared_task
 from celery.utils.log import get_task_logger
 from contextlib import contextmanager
 from django.conf import settings
-from django.core import cache
+from django.core.cache import cache
 from django.db import transaction
 from django.utils import timezone
 from rest_framework.status import HTTP_207_MULTI_STATUS, HTTP_208_ALREADY_REPORTED

--- a/mail/enums.py
+++ b/mail/enums.py
@@ -356,9 +356,3 @@ class QuantityCodeEnum(IntegerChoices):
     # Number of watt = 117, "Number of watt"
     # Kilogram Raw Sugar = 118, "Kilogram Raw Sugar"
     # KAC: (KG net of Acesulfame Potassium) = 119, "KAC: (KG net of Acesulfame Potassium)"
-
-
-class EmailType:
-    LICENCE_REJECTED = "licence_rejected"
-    SPIRE_LICENCE_DETAILS = "spire_licence_details"  # it can be either licence_data or licence_reply
-    LITE_LICENCE_DETAILS = "lite_licence_details"

--- a/mail/enums.py
+++ b/mail/enums.py
@@ -357,6 +357,8 @@ class QuantityCodeEnum(IntegerChoices):
     # Kilogram Raw Sugar = 118, "Kilogram Raw Sugar"
     # KAC: (KG net of Acesulfame Potassium) = 119, "KAC: (KG net of Acesulfame Potassium)"
 
+
 class EmailType:
     LICENCE_REJECTED = "licence_rejected"
-    LICENCE_DETAILS = "licence_details"
+    SPIRE_LICENCE_DETAILS = "spire_licence_details"  # it can be either licence_data or licence_reply
+    LITE_LICENCE_DETAILS = "lite_licence_details"

--- a/mail/enums.py
+++ b/mail/enums.py
@@ -356,3 +356,7 @@ class QuantityCodeEnum(IntegerChoices):
     # Number of watt = 117, "Number of watt"
     # Kilogram Raw Sugar = 118, "Kilogram Raw Sugar"
     # KAC: (KG net of Acesulfame Potassium) = 119, "KAC: (KG net of Acesulfame Potassium)"
+
+class EmailType:
+    LICENCE_REJECTED = "licence_rejected"
+    LICENCE_DETAILS = "licence_details"

--- a/mail/libraries/builders.py
+++ b/mail/libraries/builders.py
@@ -274,6 +274,19 @@ def build_email_message(email_message_dto: EmailMessageDto) -> MIMEMultipart:
     return multipart_msg
 
 
+def build_licence_rejected_email_message(email_message_dto: EmailMessageDto) -> MIMEMultipart:
+    logger.info("Building licences rejected notification email message")
+    multipart_msg = MIMEMultipart()
+    multipart_msg["From"] = settings.EMAIL_USER
+    multipart_msg["To"] = ",".join(settings.NOTIFY_USERS)
+    multipart_msg["Subject"] = email_message_dto.subject
+    multipart_msg["name"] = email_message_dto.subject
+    body = MIMEText(email_message_dto.body)
+    multipart_msg.attach(body)
+    logger.info("Message headers: %s", multipart_msg.items())
+    return multipart_msg
+
+
 def _validate_dto(email_message_dto):
     if email_message_dto is None:
         raise TypeError("None email_message_dto received!")

--- a/mail/libraries/builders.py
+++ b/mail/libraries/builders.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText

--- a/mail/libraries/routing_controller.py
+++ b/mail/libraries/routing_controller.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from mail.auth import BasicAuthentication, ModernAuthentication
-from mail.enums import ExtractTypeEnum, MailReadStatuses, ReceptionStatusEnum, SourceEnum
+from mail.enums import EmailType, ExtractTypeEnum, MailReadStatuses, ReceptionStatusEnum, SourceEnum
 from mail.libraries.builders import build_email_message
 from mail.libraries.data_processors import (
     lock_db_for_sending_transaction,
@@ -175,6 +175,8 @@ def send(email_message_dto: EmailMessageDto):
 
 
 def _collect_and_send(mail: Mail):
+    from mail.celery_tasks import send_email_task
+
     logger.info("Sending Mail [%s] of extract type %s", mail.id, mail.extract_type)
 
     message_to_send_dto = to_email_message_dto_from(mail)
@@ -185,11 +187,11 @@ def _collect_and_send(mail: Mail):
 
     if message_to_send_dto:
         if message_to_send_dto.receiver != SourceEnum.LITE and message_to_send_dto.subject:
-            send(message_to_send_dto)
-            update_mail(mail, message_to_send_dto)
+            # Schedule a task to send email
+            send_email_task.delay(EmailType.LICENCE_DETAILS, mail.id, message_to_send_dto)
 
             logger.info(
-                "Mail [%s] routed from [%s] to [%s] with subject %s",
+                "Scheduled sending of mail [%s] from [%s] to [%s] with subject %s",
                 mail.id,
                 message_to_send_dto.sender,
                 message_to_send_dto.receiver,

--- a/mail/libraries/routing_controller.py
+++ b/mail/libraries/routing_controller.py
@@ -188,7 +188,7 @@ def _collect_and_send(mail: Mail):
     if message_to_send_dto:
         if message_to_send_dto.receiver != SourceEnum.LITE and message_to_send_dto.subject:
             # Schedule a task to send email
-            send_email_task.delay(EmailType.LICENCE_DETAILS, mail.id, message_to_send_dto)
+            send_email_task.delay(EmailType.SPIRE_LICENCE_DETAILS, mail.id, message_to_send_dto)
 
             logger.info(
                 "Scheduled sending of mail [%s] from [%s] to [%s] with subject %s",

--- a/mail/tests/test_celery_task.py
+++ b/mail/tests/test_celery_task.py
@@ -5,6 +5,7 @@ import pytest
 from django.test import TestCase, override_settings
 
 from mail.celery_tasks import manage_inbox, notify_users_of_rejected_licences
+from mail.libraries.email_message_dto import EmailMessageDto
 
 
 class NotifyUsersOfRejectedMailTests(TestCase):

--- a/mail/tests/test_celery_task.py
+++ b/mail/tests/test_celery_task.py
@@ -1,21 +1,36 @@
 import email.mime.multipart
 import pytest
 
+from datetime import datetime, timezone
+from parameterized import parameterized
 from unittest import mock
 from django.test import TestCase, override_settings
 
 from mail.celery_tasks import manage_inbox, notify_users_of_rejected_licences
+from mail.enums import ExtractTypeEnum, ReceptionStatusEnum, SourceEnum
+from mail.libraries.routing_controller import check_and_route_emails
+from mail.models import LicenceData, Mail
+from mail.tests.libraries.client import LiteHMRCTestClient
 
 
 class NotifyUsersOfRejectedMailTests(TestCase):
+    @parameterized.expand(
+        [
+            # lock_acquired
+            ([True],),
+            ([False, True],),
+        ]
+    )
     @override_settings(EMAIL_USER="test@example.com", NOTIFY_USERS=["notify@example.com"])  # /PS-IGNORE
     @mock.patch("mail.celery_tasks.smtp_send")
     @mock.patch("mail.celery_tasks.cache")
-    def test_send_success(self, mock_cache, mock_smtp_send):
-        mock_cache.add.return_value = True
+    def test_send_rejected_notification_email_success(self, lock_acquired, mock_cache, mock_smtp_send):
+        """Test sending of licence rejected emails without and with retry scenario"""
+        mock_cache.add.side_effect = lock_acquired
 
         notify_users_of_rejected_licences.delay("123", "CHIEF_SPIRE_licenceReply_202401180900_42557")
 
+        assert mock_cache.add.call_count == len(lock_acquired)
         mock_smtp_send.assert_called_once()
 
         self.assertEqual(len(mock_smtp_send.call_args_list), 1)
@@ -37,7 +52,7 @@ class NotifyUsersOfRejectedMailTests(TestCase):
         self.assertEqual(text_payload.get_payload(), expected_body)
 
 
-class ManageInboxTests(TestCase):
+class ManageInboxTests(LiteHMRCTestClient):
     @mock.patch("mail.celery_tasks.check_and_route_emails")
     def test_manage_inbox(self, mock_function):
         manage_inbox()
@@ -49,3 +64,53 @@ class ManageInboxTests(TestCase):
         with pytest.raises(Exception) as excinfo:
             manage_inbox()
         assert str(excinfo.value) == "Test Error"
+
+    @parameterized.expand(
+        [
+            # lock_acquired
+            ([True],),
+            ([False, True],),
+        ]
+    )
+    @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
+    @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
+    @mock.patch("mail.celery_tasks.smtp_send")
+    @mock.patch("mail.celery_tasks.cache")
+    @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
+    def test_sending_of_new_message_from_spire_success(
+        self,
+        lock_acquired,
+        email_dtos,
+        mock_cache,
+        mock_smtp_send,
+        mock_get_hmrc_to_dit_mailserver,
+        mock_get_spire_to_dit_mailserver,
+    ):
+        """Test sending of email when a message from SPIRE is processed without and with retry scenario"""
+        email_dtos.return_value = []
+        mock_cache.add.side_effect = lock_acquired
+
+        # When a new message is processed from inbox it will be created with 'pending' status
+        pending_mail = Mail.objects.create(
+            extract_type=ExtractTypeEnum.LICENCE_DATA,
+            edi_filename=self.licence_data_file_name,
+            edi_data=self.licence_data_file_body.decode("utf-8"),
+            status=ReceptionStatusEnum.PENDING,
+            sent_at=datetime.now(timezone.utc),
+        )
+        LicenceData.objects.create(
+            mail=pending_mail,
+            source_run_number=78120,
+            hmrc_run_number=78120,
+            source=SourceEnum.SPIRE,
+            licence_ids=f"{78120}",
+        )
+
+        check_and_route_emails()
+
+        # assert that the pending mail is sent and status updated
+        mail = Mail.objects.get(id=pending_mail.id)
+        self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_PENDING)
+
+        assert mock_cache.add.call_count == len(lock_acquired)
+        mock_smtp_send.assert_called_once()

--- a/mail/tests/test_end_to_end.py
+++ b/mail/tests/test_end_to_end.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 from urllib.parse import quote
 
 import requests
@@ -25,7 +26,9 @@ def get_smtp_body():
 
 
 class EndToEndTests(LiteHMRCTestClient):
-    def test_send_email_to_hmrc_e2e(self):
+    @mock.patch("mail.celery_tasks.cache")
+    def test_send_email_to_hmrc_e2e(self, mock_cache):
+        mock_cache.add.return_value = True
         clear_stmp_mailbox()
         self.client.get(reverse("mail:set_all_to_reply_sent"))
         self.client.post(
@@ -52,7 +55,9 @@ class EndToEndTests(LiteHMRCTestClient):
 
 @override_settings(CHIEF_SOURCE_SYSTEM=ChiefSystemEnum.ICMS)
 class ICMSEndToEndTests(testcases.TestCase):
-    def test_icms_send_email_to_hmrc_fa_oil_e2e(self):
+    @mock.patch("mail.celery_tasks.cache")
+    def test_icms_send_email_to_hmrc_fa_oil_e2e(self, mock_cache):
+        mock_cache.add.return_value = True
         clear_stmp_mailbox()
         self.client.get(reverse("mail:set_all_to_reply_sent"))
 
@@ -113,7 +118,9 @@ class ICMSEndToEndTests(testcases.TestCase):
         licence_payload: LicencePayload = ld.licence_payloads.first()
         assert licence_payload.reference == "IMA/2022/00001"
 
-    def test_icms_send_email_to_hmrc_fa_dfl_e2e(self):
+    @mock.patch("mail.celery_tasks.cache")
+    def test_icms_send_email_to_hmrc_fa_dfl_e2e(self, mock_cache):
+        mock_cache.add.return_value = True
         clear_stmp_mailbox()
         self.client.get(reverse("mail:set_all_to_reply_sent"))
 
@@ -177,7 +184,9 @@ class ICMSEndToEndTests(testcases.TestCase):
             response = self.client.get(f"{reverse('mail:licence')}?id={encoded_reference_code}")
             self.assertEqual(response.json()["status"], "reply_pending", f"{ref} has incorrect status")
 
-    def test_icms_send_email_to_hmrc_fa_sil_e2e(self):
+    @mock.patch("mail.celery_tasks.cache")
+    def test_icms_send_email_to_hmrc_fa_sil_e2e(self, mock_cache):
+        mock_cache.add.return_value = True
         clear_stmp_mailbox()
         self.client.get(reverse("mail:set_all_to_reply_sent"))
 
@@ -198,7 +207,9 @@ class ICMSEndToEndTests(testcases.TestCase):
         response = self.client.get(f"{reverse('mail:licence')}?id={encoded_reference_code}")
         self.assertEqual(response.json()["status"], "reply_pending")
 
-    def test_icms_send_email_to_hmrc_sanctions_e2e(self):
+    @mock.patch("mail.celery_tasks.cache")
+    def test_icms_send_email_to_hmrc_sanctions_e2e(self, mock_cache):
+        mock_cache.add.return_value = True
         clear_stmp_mailbox()
         self.client.get(reverse("mail:set_all_to_reply_sent"))
 

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -53,9 +53,11 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
 
         self.assertEqual(result, expected)
 
-    @mock.patch("mail.celery_tasks.send")
-    def test_licence_is_marked_as_processed_after_sending(self, send):
-        send.return_value = None
+    @mock.patch("mail.celery_tasks.smtp_send")
+    @mock.patch("mail.celery_tasks.cache")
+    def test_licence_is_marked_as_processed_after_sending(self, mock_cache, mock_smtp_send):
+        mock_cache.add.return_value = True
+        mock_smtp_send.return_value = None
         send_licence_details_to_hmrc.delay()
 
         self.assertEqual(Mail.objects.count(), 1)

--- a/mail/tests/test_resend_email.py
+++ b/mail/tests/test_resend_email.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.core.management import call_command
+from django.test import override_settings
 
 from mail.enums import ExtractTypeEnum, ReceptionStatusEnum, SourceEnum
 from mail.libraries.email_message_dto import EmailMessageDto
@@ -70,9 +71,10 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         self.assertEqual(mail.extract_type, ExtractTypeEnum.LICENCE_DATA)
         self.assertEqual(mock_send.call_count, 1)
 
+    @override_settings(SEND_REJECTED_EMAIL=False)
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
     @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
-    @mock.patch("mail.libraries.routing_controller.send")
+    @mock.patch("mail.libraries.routing_controller.smtp_send")
     @mock.patch("mail.celery_tasks.smtp_send")
     @mock.patch("mail.celery_tasks.cache")
     @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
@@ -81,7 +83,7 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         email_dtos,
         mock_cache,
         mock_smtp_send,
-        mock_send,
+        mock_routing_smtp_send,
         mock_get_hmrc_to_dit_mailserver,
         mock_get_spire_to_dit_mailserver,
     ):
@@ -141,11 +143,11 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         self.assertEqual(mail.id, pending_mail.id)
         self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_SENT)
         self.assertEqual(mail.extract_type, ExtractTypeEnum.LICENCE_REPLY)
-        mock_send.assert_called_once()
+        mock_routing_smtp_send.assert_called_once()
 
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
     @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
-    @mock.patch("mail.libraries.routing_controller.send")
+    @mock.patch("mail.libraries.routing_controller.smtp_send")
     @mock.patch("mail.celery_tasks.smtp_send")
     @mock.patch("mail.celery_tasks.cache")
     @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
@@ -154,7 +156,7 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         email_dtos,
         mock_cache,
         mock_smtp_send,
-        mock_send,
+        mock_routing_smtp_send,
         mock_get_hmrc_to_dit_mailserver,
         mock_get_spire_to_dit_mailserver,
     ):
@@ -213,4 +215,4 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         self.assertEqual(mail.id, pending_mail.id)
         self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_SENT)
         self.assertEqual(mail.extract_type, ExtractTypeEnum.USAGE_DATA)
-        mock_send.assert_called_once()
+        mock_routing_smtp_send.assert_called_once()

--- a/mail/tests/test_resend_email.py
+++ b/mail/tests/test_resend_email.py
@@ -74,7 +74,7 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
     @override_settings(SEND_REJECTED_EMAIL=False)
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
     @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
-    @mock.patch("mail.libraries.routing_controller.smtp_send")
+    @mock.patch("mail.management.commands.resend_email.send")
     @mock.patch("mail.celery_tasks.smtp_send")
     @mock.patch("mail.celery_tasks.cache")
     @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
@@ -83,7 +83,7 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         email_dtos,
         mock_cache,
         mock_smtp_send,
-        mock_routing_smtp_send,
+        mock_send,
         mock_get_hmrc_to_dit_mailserver,
         mock_get_spire_to_dit_mailserver,
     ):
@@ -143,11 +143,11 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         self.assertEqual(mail.id, pending_mail.id)
         self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_SENT)
         self.assertEqual(mail.extract_type, ExtractTypeEnum.LICENCE_REPLY)
-        mock_routing_smtp_send.assert_called_once()
+        mock_send.assert_called_once()
 
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
     @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
-    @mock.patch("mail.libraries.routing_controller.smtp_send")
+    @mock.patch("mail.management.commands.resend_email.send")
     @mock.patch("mail.celery_tasks.smtp_send")
     @mock.patch("mail.celery_tasks.cache")
     @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
@@ -156,7 +156,7 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         email_dtos,
         mock_cache,
         mock_smtp_send,
-        mock_routing_smtp_send,
+        mock_send,
         mock_get_hmrc_to_dit_mailserver,
         mock_get_spire_to_dit_mailserver,
     ):
@@ -215,4 +215,4 @@ class LITEHMRCResendEmailTests(LiteHMRCTestClient):
         self.assertEqual(mail.id, pending_mail.id)
         self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_SENT)
         self.assertEqual(mail.extract_type, ExtractTypeEnum.USAGE_DATA)
-        mock_routing_smtp_send.assert_called_once()
+        mock_send.assert_called_once()

--- a/mail/tests/test_select_email_for_sending.py
+++ b/mail/tests/test_select_email_for_sending.py
@@ -104,12 +104,14 @@ class EmailSelectTests(LiteHMRCTestClient):
 
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
     @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
-    @mock.patch("mail.libraries.routing_controller.send")
+    @mock.patch("mail.celery_tasks.smtp_send")
+    @mock.patch("mail.celery_tasks.cache")
     @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
     def test_case1_sending_of_pending_licencedata_mails(
         self,
         email_dtos,
-        send_mail,
+        mock_cache,
+        mock_smtp_send,
         mock_get_hmrc_to_dit_mailserver,
         mock_get_spire_to_dit_mailserver,
     ):
@@ -127,7 +129,8 @@ class EmailSelectTests(LiteHMRCTestClient):
         num_sent_mails = 3
         start_run_number = 78120
         email_dtos.return_value = []
-        send_mail.wraps = lambda x: x
+        mock_cache.add.return_value = True
+        mock_smtp_send.wraps = lambda x: x
         for i in range(num_sent_mails):
             mail = self.get_mail(extract_type=ExtractTypeEnum.LICENCE_DATA, status=ReceptionStatusEnum.REPLY_SENT)
             LicenceData.objects.create(
@@ -159,17 +162,19 @@ class EmailSelectTests(LiteHMRCTestClient):
 
         # assert that the pending mail is sent and status updated
         mail = Mail.objects.get(id=pending_mail.id)
-        send_mail.assert_called_once()
+        mock_smtp_send.assert_called_once()
         self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_PENDING)
 
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
     @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
-    @mock.patch("mail.libraries.routing_controller.send")
+    @mock.patch("mail.celery_tasks.smtp_send")
+    @mock.patch("mail.celery_tasks.cache")
     @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
     def test_case2_sending_of_pending_usagedata_mails(
         self,
         email_dtos,
-        send_mail,
+        mock_cache,
+        mock_smtp_send,
         mock_get_hmrc_to_dit_mailserver,
         mock_get_spire_to_dit_mailserver,
     ):
@@ -188,7 +193,8 @@ class EmailSelectTests(LiteHMRCTestClient):
         num_sent_mails = 3
         start_run_number = 78120
         email_dtos.return_value = []
-        send_mail.wraps = lambda x: x
+        mock_cache.add.return_value = True
+        mock_smtp_send.wraps = lambda x: x
         for i in range(num_sent_mails):
             mail = self.get_mail(extract_type=ExtractTypeEnum.LICENCE_DATA, status=ReceptionStatusEnum.REPLY_SENT)
             LicenceData.objects.create(
@@ -223,18 +229,20 @@ class EmailSelectTests(LiteHMRCTestClient):
 
             # assert that the pending mail is sent and status updated
             mail = Mail.objects.get(id=pending_mails[i].id)
-            send_mail.assert_called()
-            self.assertEqual(send_mail.call_count, int(i + 1))
+            mock_smtp_send.assert_called()
+            self.assertEqual(mock_smtp_send.call_count, int(i + 1))
             self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_SENT)
 
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
     @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
-    @mock.patch("mail.libraries.routing_controller.send")
+    @mock.patch("mail.celery_tasks.smtp_send")
+    @mock.patch("mail.celery_tasks.cache")
     @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
     def test_case3_sending_of_pending_licencedata_and_usagedata_mails_1(
         self,
         email_dtos,
-        send_mail,
+        mock_cache,
+        mock_smtp_send,
         mock_get_hmrc_to_dit_mailserver,
         mock_get_spire_to_dit_mailserver,
     ):
@@ -255,7 +263,8 @@ class EmailSelectTests(LiteHMRCTestClient):
         num_sent_mails = 3
         start_run_number = 78120
         email_dtos.return_value = []
-        send_mail.wraps = lambda x: x
+        mock_cache.add.return_value = True
+        mock_smtp_send.wraps = lambda x: x
         for i in range(num_sent_mails):
             mail = self.get_mail(extract_type=ExtractTypeEnum.LICENCE_DATA, status=ReceptionStatusEnum.REPLY_SENT)
             LicenceData.objects.create(
@@ -309,8 +318,8 @@ class EmailSelectTests(LiteHMRCTestClient):
 
             # assert that the pending mail is sent and status updated
             mail = Mail.objects.get(id=pending_mails[i].id)
-            send_mail.assert_called()
-            self.assertEqual(send_mail.call_count, int(i + 1))
+            mock_smtp_send.assert_called()
+            self.assertEqual(mock_smtp_send.call_count, int(i + 1))
 
             if mail.extract_type == ExtractTypeEnum.LICENCE_DATA:
                 self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_PENDING)
@@ -319,12 +328,14 @@ class EmailSelectTests(LiteHMRCTestClient):
 
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")
     @mock.patch("mail.libraries.routing_controller.get_hmrc_to_dit_mailserver")
-    @mock.patch("mail.libraries.routing_controller.send")
+    @mock.patch("mail.celery_tasks.smtp_send")
+    @mock.patch("mail.celery_tasks.cache")
     @mock.patch("mail.libraries.routing_controller.get_email_message_dtos")
     def test_case3_sending_of_pending_licencedata_and_usagedata_mails_2(
         self,
         email_dtos,
-        send_mail,
+        mock_cache,
+        mock_smtp_send,
         mock_get_hmrc_to_dit_mailserver,
         mock_get_spire_to_dit_mailserver,
     ):
@@ -342,7 +353,8 @@ class EmailSelectTests(LiteHMRCTestClient):
         start_run_number = 78120
         usage_run_number = 5050
         email_dtos.return_value = []
-        send_mail.wraps = lambda x: x
+        mock_cache.add.return_value = True
+        mock_smtp_send.wraps = lambda x: x
         for i in range(num_sent_mails):
             mail = self.get_mail(extract_type=ExtractTypeEnum.LICENCE_DATA, status=ReceptionStatusEnum.REPLY_SENT)
             LicenceData.objects.create(
@@ -390,7 +402,7 @@ class EmailSelectTests(LiteHMRCTestClient):
 
         # assert that the pending mail is sent and status updated
         mail = Mail.objects.get(id=pending_mail.id)
-        send_mail.assert_called_once()
+        mock_smtp_send.assert_called_once()
         self.assertEqual(mail.status, ReceptionStatusEnum.REPLY_PENDING)
 
     @mock.patch("mail.libraries.routing_controller.get_spire_to_dit_mailserver")

--- a/mail/tests/test_send_lite_licence_updates_task.py
+++ b/mail/tests/test_send_lite_licence_updates_task.py
@@ -1,10 +1,8 @@
-import pytest
-
 from unittest import mock
 
 from parameterized import parameterized
 
-from mail.celery_tasks import send_licence_details_to_hmrc, SMTPConnectionLocked
+from mail.celery_tasks import send_licence_details_to_hmrc
 from mail.libraries.lite_to_edifact_converter import EdifactValidationError
 from mail.enums import ReceptionStatusEnum
 from mail.models import LicencePayload, Mail


### PR DESCRIPTION
## Change description

We use SMTP to send emails. As we process messages we also have a requirement to send emails from multiple tasks, because of this we may open multiple SMTP connections concurrently. This results in error if the number of concurrent connections exceed maximum allowed value.

To manage this reliably we are restricting access to this shared resource using a lock. This is achieved by deferring all email sending functionality to a dedicated task.
Before sending email it first tries to acquire a lock.
  - If there are no active connections then it acquires lock and sends email.
     In some cases we need to update state which is handled in subtasks linked to the parent task.
  - If there is active connection (lock acquisition fails) then it raises an exception to trigger an automatic retry.
     If all retries fail then manual intervention may be required (unlikely)

`Co-authored-by: Le H Ngo <hgle.ngo@gmail.com>`

[LTD-4652](https://uktrade.atlassian.net/browse/LTD-4652)

[LTD-4652]: https://uktrade.atlassian.net/browse/LTD-4652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ