### PR TITLE
LTD-4630: Remove references to process_tasks management command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,6 @@ cov-report:
 run-icms:
 	docker-compose -f docker-compose.yml -f docker-compose-icms.yml up --build -d
 
-process-tasks:
-	docker exec -it lite-hmrc-intg pipenv run ./manage.py process_tasks --log-std
-
 # e.g. make pipenv COMMAND="install --dev requests-mock"
 pipenv:
 	docker exec -it lite-hmrc-intg pipenv ${COMMAND}

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,4 @@
 # See gunicorn.conf.py for more configuration.
 web: python manage.py migrate && gunicorn conf.wsgi:application
-worker: python manage.py process_tasks --log-std
 celeryworker: celery -A conf worker -l info
 celerybeat: celery -A conf beat -l info

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ To run in docker do the following
 - Initial setup (run once):
   - Run migrations: `make migrate`
   - Create super user: `make createsuperuser`
-- Start the task runner: `make process-tasks`
 
 
 ### Running locally


### PR DESCRIPTION
## Change description

This is a management command in background_task which is used to start the tasks. We have completely removed background_tasks and switched to celery so this are no longer required.