### PR TITLE
[LTD-5022] Support milligrams unit for ingested good data

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -195,6 +195,7 @@ class UnitMapping(enum.Enum):
     MTQ = 2  # meters_cubed
     MIR = 74  # millilitre
     ITG = 30  # intangible
+    MIM = 111  # milligram
 
     @classmethod
     def serializer_choices(cls):

--- a/mail/tests/files/licence_payload_file
+++ b/mail/tests/files/licence_payload_file
@@ -34,6 +34,13 @@
               "description": "",
               "unit": "NAR",
               "quantity": 10.0
+          },
+          {
+              "id": "f95ded2a-354f-46f1-a572-c7f97d63bed2",
+              "name": "Stock",
+              "description": "",
+              "unit": "MIM",
+              "quantity": 11.0
           }
       ]
   }

--- a/mail/tests/test_end_to_end.py
+++ b/mail/tests/test_end_to_end.py
@@ -45,8 +45,9 @@ class EndToEndTests(LiteHMRCTestClient):
 5\foreignTrader\End User\42 Road, London, Buckinghamshire\\\\\\GB
 6\restrictions\Provisos may apply please see licence
 7\line\1\\\\\Sporting shotgun\Q\\030\\10\\\\\\
-8\end\licence\7
-9\fileTrailer\1"""
+8\line\2\\\\\Stock\Q\\111\\11.0\\\\\\
+9\end\licence\8
+10\fileTrailer\1"""
         assert body == expected_mail_body  # nosec
         encoded_reference_code = quote("GBSIEL/2020/0000001/P", safe="")
         response = self.client.get(f"{reverse('mail:licence')}?id={encoded_reference_code}")

--- a/mail/tests/test_enums.py
+++ b/mail/tests/test_enums.py
@@ -13,7 +13,9 @@ class UnitMappingTests(unittest.TestCase):
             ("MTR", 57),
             ("LTR", 94),
             ("MTQ", 2),
+            ("MIR", 74),
             ("ITG", 30),
+            ("MIM", 111),
         ]
 
         for code, value in data:
@@ -26,6 +28,6 @@ class UnitMappingTests(unittest.TestCase):
 
     def test_serializer_choices(self):
         choices = UnitMapping.serializer_choices()
-        expected = ["NAR", "GRM", "KGM", "MTK", "MTR", "LTR", "MTQ", "MIR", "ITG"]
+        expected = ["NAR", "GRM", "KGM", "MTK", "MTR", "LTR", "MTQ", "MIR", "ITG", "MIM"]
 
         self.assertEqual(choices, expected)

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -47,8 +47,9 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             + "\n5\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
             + "\n6\\restrictions\\Provisos may apply please see licence"
             + "\n7\\line\\1\\\\\\\\\\Sporting shotgun\\Q\\\\030\\\\10\\\\\\\\\\\\"
-            + "\n8\\end\\licence\\7"
-            + "\n9\\fileTrailer\\1\n"
+            + "\n8\\line\\2\\\\\\\\\\Stock\\Q\\\\111\\\\11.0\\\\\\\\\\\\"
+            + "\n9\\end\\licence\\8"
+            + "\n10\\fileTrailer\\1\n"
         )
 
         self.assertEqual(result, expected)
@@ -110,8 +111,9 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             + "\n7\\foreignTrader\\End User\\42 Road, London, Buckinghamshire\\\\\\\\\\\\GB"
             + "\n8\\restrictions\\Provisos may apply please see licence"
             + "\n9\\line\\1\\\\\\\\\\Sporting shotgun\\Q\\\\030\\\\15\\\\\\\\\\\\"
-            + "\n10\\end\\licence\\7"
-            + "\n11\\fileTrailer\\2\n"
+            + "\n10\\line\\2\\\\\\\\\\Stock\\Q\\\\111\\\\11.0\\\\\\\\\\\\"
+            + "\n11\\end\\licence\\8"
+            + "\n12\\fileTrailer\\2\n"
         )
 
         self.assertEqual(result, expected)


### PR DESCRIPTION
Ensure that we handle translating lite-api's `MIM` unit to chief's unit integer for milligrams.