### PR TITLE
Add ruff unused import check to pre-commit and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ./venv
+            - ./.venv
           key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
 
       - run:
@@ -60,7 +60,7 @@ jobs:
       - run:
           name: Upload code coverage
           command: ./codecov
-  
+
   tests_postgres13:
     docker:
       - image: cimg/python:3.8.17
@@ -105,7 +105,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ./venv
+            - ./.venv
           key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
 
       - run:
@@ -127,17 +127,14 @@ jobs:
     steps:
       - checkout
 
+      - run: pipenv install pre-commit
+
       - restore_cache:
-          key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum ".pre-commit-config.yaml" }}
 
       - run:
           name: Install Dependencies
           command: pipenv sync --dev
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
 
       - run:
           name: Prospector
@@ -155,6 +152,18 @@ jobs:
           name: Bandit
           command: |
             pipenv run bandit -c bandit.yaml -r .
+
+      - run:
+          name: Ruff
+          command: pipenv run pre-commit run ruff --from-ref origin/HEAD --to-ref HEAD
+
+      - save_cache:
+          paths:
+            - ./.venv
+            - ~/.cache/pre-commit
+          # the cache key changes whenever any of the branch name, Pipfile.lock checksum, or .pre-commit-config.yaml checksum change
+          key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum ".pre-commit-config.yaml" }}
+
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ./.venv
+            - ./venv
           key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
 
       - run:
@@ -105,7 +105,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ./.venv
+            - ./venv
           key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
 
       - run:
@@ -159,7 +159,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ./.venv
+            - ./venv
             - ~/.cache/pre-commit
           # the cache key changes whenever any of the branch name, Pipfile.lock checksum, or .pre-commit-config.yaml checksum change
           key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum ".pre-commit-config.yaml" }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: (exporter/assets/built/|caseworker/assets/built/)
 repos:
-  # ruff-pre-commit docs recommend running ruff before black
+    # ruff-pre-commit docs recommend running ruff before black
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.1.4
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
 exclude: (exporter/assets/built/|caseworker/assets/built/)
 repos:
+  # ruff-pre-commit docs recommend running ruff before black
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.1.4
+      hooks:
+        # Config for ruff lives in pyproject.toml
+        - id: ruff
+          args: [ --fix ]
     - repo: https://github.com/psf/black
       rev: 22.3.0
       hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.black]
 line-length = 120
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -27,3 +27,6 @@ exclude = '''
 [tool.isort]
 profile = 'black'
 line_length = 120  # To match Black's line-length above.
+
+[tool.ruff.lint]
+select = ["F401"]


### PR DESCRIPTION
Adds the ruff unused import check to pre-commit and CI following the pattern established in lite-frontend, lite-api, lite-routing.