### PR TITLE
Update UnitMapping codes to match HMRC list

### DIFF
--- a/mail/enums.py
+++ b/mail/enums.py
@@ -191,7 +191,7 @@ class UnitMapping(enum.Enum):
     KGM = 23  # kilogram
     MTK = 45  # meters_squared
     MTR = 57  # meters
-    LTR = 94  # litre
+    LTR = 76  # litre
     MTQ = 2  # meters_cubed
     MLT = 74  # millilitre
     ITG = 30  # intangible

--- a/mail/enums.py
+++ b/mail/enums.py
@@ -192,7 +192,7 @@ class UnitMapping(enum.Enum):
     MTK = 45  # meters_squared
     MTR = 57  # meters
     LTR = 76  # litre
-    MTQ = 2  # meters_cubed
+    MTQ = 87  # meters_cubed
     MLT = 74  # millilitre
     ITG = 30  # intangible
     MGM = 111  # milligram

--- a/mail/tests/files/licence_payload_file
+++ b/mail/tests/files/licence_payload_file
@@ -76,6 +76,13 @@
             "description": "",
             "unit": "MIM",
             "quantity": 20.0
+          },
+          {
+            "id": "b642b709-36c7-4010-8e43-e7b8813fbde9",
+            "name": "A bottle of water",
+            "description": "",
+            "unit": "LTR",
+            "quantity": 1.0
           }
       ]
   }

--- a/mail/tests/test_end_to_end.py
+++ b/mail/tests/test_end_to_end.py
@@ -51,8 +51,9 @@ class EndToEndTests(LiteHMRCTestClient):
 11\line\5\\\\\Chemical\Q\\110\\20.0\\\\\\
 12\line\6\\\\\Chemical\Q\\074\\20.0\\\\\\
 13\line\7\\\\\Old Chemical\Q\\111\\20.0\\\\\\
-14\end\licence\13
-15\fileTrailer\1"""
+14\line\8\\\\\A bottle of water\Q\\076\\1.0\\\\\\
+15\end\licence\14
+16\fileTrailer\1"""
         assert body == expected_mail_body  # nosec
         encoded_reference_code = quote("GBSIEL/2020/0000001/P", safe="")
         response = self.client.get(f"{reverse('mail:licence')}?id={encoded_reference_code}")

--- a/mail/tests/test_enums.py
+++ b/mail/tests/test_enums.py
@@ -11,7 +11,7 @@ class UnitMappingTests(unittest.TestCase):
             ("KGM", 23),
             ("MTK", 45),
             ("MTR", 57),
-            ("LTR", 94),
+            ("LTR", 76),
             ("MTQ", 2),
             ("MLT", 74),
             ("ITG", 30),

--- a/mail/tests/test_enums.py
+++ b/mail/tests/test_enums.py
@@ -12,7 +12,7 @@ class UnitMappingTests(unittest.TestCase):
             ("MTK", 45),
             ("MTR", 57),
             ("LTR", 76),
-            ("MTQ", 2),
+            ("MTQ", 87),
             ("MLT", 74),
             ("ITG", 30),
             ("MGM", 111),

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -53,8 +53,9 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             + "\n11\\line\\5\\\\\\\\\\Chemical\\Q\\\\110\\\\20.0\\\\\\\\\\\\"
             + "\n12\\line\\6\\\\\\\\\\Chemical\\Q\\\\074\\\\20.0\\\\\\\\\\\\"
             + "\n13\\line\\7\\\\\\\\\\Old Chemical\\Q\\\\111\\\\20.0\\\\\\\\\\\\"
-            + "\n14\\end\\licence\\13"
-            + "\n15\\fileTrailer\\1\n"
+            + "\n14\\line\\8\\\\\\\\\\A bottle of water\\Q\\\\076\\\\1.0\\\\\\\\\\\\"
+            + "\n15\\end\\licence\\14"
+            + "\n16\\fileTrailer\\1\n"
         )
 
         self.assertEqual(result, expected)
@@ -122,8 +123,9 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
             + "\n13\\line\\5\\\\\\\\\\Chemical\\Q\\\\110\\\\20.0\\\\\\\\\\\\"
             + "\n14\\line\\6\\\\\\\\\\Chemical\\Q\\\\074\\\\20.0\\\\\\\\\\\\"
             + "\n15\\line\\7\\\\\\\\\\Old Chemical\\Q\\\\111\\\\20.0\\\\\\\\\\\\"
-            + "\n16\\end\\licence\\13"
-            + "\n17\\fileTrailer\\2\n"
+            + "\n16\\line\\8\\\\\\\\\\A bottle of water\\Q\\\\076\\\\1.0\\\\\\\\\\\\"
+            + "\n17\\end\\licence\\14"
+            + "\n18\\fileTrailer\\2\n"
         )
 
         self.assertEqual(result, expected)


### PR DESCRIPTION
This updates the units of measurement codes to match the lists published by HMRC. More context is given in the ticket.

[LTD-5293](https://uktrade.atlassian.net/browse/LTD-5293)

[LTD-5293]: https://uktrade.atlassian.net/browse/LTD-5293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ