### PR TITLE
[LTD-5327] Update sentry scope pushing call after major version bump

### DIFF
--- a/mail/libraries/helpers.py
+++ b/mail/libraries/helpers.py
@@ -338,7 +338,7 @@ def sort_dtos_by_date(input_dtos):
 
 def log_to_sentry(message, extra=None, level="info"):
     extra = extra or {}
-    with sentry_sdk.push_scope() as scope:
+    with sentry_sdk.new_scope() as scope:
         for key, value in extra.items():
             scope.set_extra(key, value)
         sentry_sdk.capture_message(message, level=level)

--- a/mail/tests/libraries/test_helpers.py
+++ b/mail/tests/libraries/test_helpers.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest import mock
+
+from mail.libraries.helpers import log_to_sentry
+
+
+class TestLogToSentry(unittest.TestCase):
+
+    @mock.patch("sentry_sdk.scope.Scope.capture_event")
+    def test_log_to_sentry(self, mock_capture_event):
+        log_to_sentry("some message", {"extra": "context"}, level="debug")
+        mock_capture_event.assert_called_with(
+            {"message": "some message", "level": "debug"},
+            scope=None,
+        )


### PR DESCRIPTION
Since the last lite-hmrc release, we have been getting fairly regular `LookupError` exceptions logged to sentry.  It's likely that is due to a backward incompatibility as we bumped sentry-sdk's major version.

This updates the call that creates a new sentry scope as per docs for upgrading from 1.x to 2.x; https://docs.sentry.io/platforms/python/migration/1.x-to-2.x#scope-configuring