### PR TITLE
Include number of unprocessed payloads in the error message

### DIFF
--- a/healthcheck/checks.py
+++ b/healthcheck/checks.py
@@ -39,9 +39,8 @@ class LicencePayloadsHealthCheck(BaseHealthCheckBackend):
         dt = timezone.now() + datetime.timedelta(seconds=settings.LICENSE_POLL_INTERVAL)
         unprocessed_payloads = LicencePayload.objects.filter(is_processed=False, received_at__lte=dt)
 
-        for unprocessed_payload in unprocessed_payloads:
-            error_message = f"Payload object has been unprocessed for over {settings.LICENSE_POLL_INTERVAL} seconds: {unprocessed_payload}"
-            self.add_error(HealthCheckException(error_message))
+        error_message = f"Number of unprocessed payloads for over {settings.LICENSE_POLL_INTERVAL} seconds: {unprocessed_payloads.count()}"
+        self.add_error(HealthCheckException(error_message))
 
 
 class PendingMailHealthCheck(BaseHealthCheckBackend):

--- a/healthcheck/tests/test_checks.py
+++ b/healthcheck/tests/test_checks.py
@@ -73,7 +73,10 @@ class MailboxAuthenticationHealthCheckTest(TestCase):
         check = LicencePayloadsHealthCheck()
         check.check_status()
         assert len(check.errors) == 1
-        assert "Payload object has been unprocessed for over" in check.errors[0].message
+        assert (
+            f"Number of unprocessed payloads for over {settings.LICENSE_POLL_INTERVAL} seconds: 1"
+            == check.errors[0].message
+        )
 
     def test_all_payloads_processed(self):
         LicencePayload.objects.create(


### PR DESCRIPTION
## Change description

If the queue is completely stopped and the number of unprocessed payloads building up then the current error message cannot convey that so include the payload count in the error message.

There is also no need to emit message for each unprocessed payload because when we process them we batch together into a single message so the delay is same for all.

**Note:** We also prioritize sending SPIRE messages, as in before looking to batch unprocessed payloads we check if we are awaiting reply or any new messages from SPIRE that need sending. If they are all concluded then only we continue. This means during busy times then payload count can increase for a period and it is expected but should get cleared as the traffic subsides.