### PR TITLE
Fix communication between LITE API and LITE HMRC

### DIFF
--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -49,7 +49,7 @@ def _authenticate(request):
 
     # TODO: remove this when migration to DBT platform is complete as this hack is only required on Gov Paas
     if is_env_gov_paas():
-        convert_url(url)
+        convert_gov_paas_url(url)
 
     if hawk_authentication_enabled():
         return Receiver(
@@ -117,5 +117,5 @@ def is_env_gov_paas() -> bool:
     return settings.IS_ENV_GOV_PAAS
 
 
-def convert_url(url):
+def convert_gov_paas_url(url):
     return url.replace("http", "https")

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -25,7 +25,7 @@ class HawkOnlyAuthentication(authentication.BaseAuthentication):
         except HawkFail as e:
             logger.warning("Failed HAWK authentication %s", e)
 
-            raise exceptions.AuthenticationFailed(f"Failed HAWK authentication")
+            raise exceptions.AuthenticationFailed("Failed HAWK authentication")
 
         except Exception as e:
             logger.error("Failed HAWK authentication %s", e)
@@ -33,7 +33,7 @@ class HawkOnlyAuthentication(authentication.BaseAuthentication):
             if settings.SENTRY_ENABLED:
                 capture_exception(e)
 
-            raise exceptions.AuthenticationFailed(f"Failed HAWK authentication")
+            raise exceptions.AuthenticationFailed("Failed HAWK authentication")
 
         return AnonymousUser(), hawk_receiver
 
@@ -47,12 +47,11 @@ def _authenticate(request):
     """
 
     if hawk_authentication_enabled():
-        url = request.build_absolute_uri()
-        logger.info(f"URL: {url}")
         return Receiver(
             _lookup_credentials,
             request.META["HTTP_HAWK_AUTHENTICATION"],
-            url,
+            # build_absolute_uri() returns 'http' which is incorrect since our clients communicate via https
+            request.build_absolute_uri().replace("http:", "https:"),
             request.method,
             content=request.body,
             content_type=request.content_type,

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -45,12 +45,13 @@ def _authenticate(request):
     """
     Raises a HawkFail exception if the passed request cannot be authenticated
     """
-
+    url = request.build_absolute_uri()
+    logger.info(f"URL: {url}, Method: {request.method}, Body: {request.body}")
     if hawk_authentication_enabled():
         return Receiver(
             _lookup_credentials,
             request.META["HTTP_HAWK_AUTHENTICATION"],
-            request.build_absolute_uri(),
+            url,
             request.method,
             content=request.body,
             content_type=request.content_type,

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -45,12 +45,11 @@ def _authenticate(request):
     """
     Raises a HawkFail exception if the passed request cannot be authenticated
     """
-
     url = request.build_absolute_uri()
 
     # TODO: remove this when migration to DBT platform is complete as this hack is only required on Gov Paas
-    if settings.IS_ENV_GOV_PAAS:
-        url.replace("http", "https")
+    if is_env_gov_paas():
+        convert_url(url)
 
     if hawk_authentication_enabled():
         return Receiver(
@@ -107,3 +106,16 @@ def hawk_authentication_enabled() -> bool:
     """
 
     return settings.HAWK_AUTHENTICATION_ENABLED
+
+
+def is_env_gov_paas() -> bool:
+    """Defined as method as you can't override settings.IS_ENV_GOV_PAAS correctly in tests.
+
+    Patch this function to get desired behaviour.
+    """
+
+    return settings.IS_ENV_GOV_PAAS
+
+
+def convert_url(url):
+    return url.replace("http", "https")

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -50,8 +50,7 @@ def _authenticate(request):
         return Receiver(
             _lookup_credentials,
             request.META["HTTP_HAWK_AUTHENTICATION"],
-            # build_absolute_uri() returns 'http' which is incorrect since our clients communicate via https
-            request.build_absolute_uri().replace("http", "https"),
+            request.build_absolute_uri(),
             request.method,
             content=request.body,
             content_type=request.content_type,

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -47,10 +47,12 @@ def _authenticate(request):
     """
 
     if hawk_authentication_enabled():
+        url = request.build_absolute_uri()
+        logger.info(f"URL: {url}")
         return Receiver(
             _lookup_credentials,
             request.META["HTTP_HAWK_AUTHENTICATION"],
-            request.build_absolute_uri(),
+            url,
             request.method,
             content=request.body,
             content_type=request.content_type,

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -50,8 +50,7 @@ def _authenticate(request):
         return Receiver(
             _lookup_credentials,
             request.META["HTTP_HAWK_AUTHENTICATION"],
-            # build_absolute_uri() returns 'http' which is incorrect since our clients communicate via https
-            request.build_absolute_uri().replace("http:", "https:"),
+            request.build_absolute_uri(),
             request.method,
             content=request.body,
             content_type=request.content_type,

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -45,7 +45,7 @@ def _authenticate(request):
     """
     Raises a HawkFail exception if the passed request cannot be authenticated
     """
-    
+
     url = request.build_absolute_uri()
 
     # TODO: remove this when migration to DBT platform is complete as this hack is only required on Gov Paas

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -45,8 +45,13 @@ def _authenticate(request):
     """
     Raises a HawkFail exception if the passed request cannot be authenticated
     """
+    
     url = request.build_absolute_uri()
-    logger.info(f"URL: {url}, Method: {request.method}, Body: {request.body}")
+
+    # TODO: remove this when migration to DBT platform is complete as this hack is only required on Gov Paas
+    if settings.IS_ENV_GOV_PAAS:
+        url.replace("http", "https")
+
     if hawk_authentication_enabled():
         return Receiver(
             _lookup_credentials,

--- a/conf/tests/test_authentication.py
+++ b/conf/tests/test_authentication.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
-from conf.authentication import convert_url
+from conf.authentication import convert_gov_paas_url
 
 
 # override_settings doesn't work - left here for reference
@@ -28,10 +28,11 @@ class TestHawkAuthentication(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
     @patch("conf.authentication.is_env_gov_paas", lambda: True)
-    @patch("conf.authentication.convert_url")
-    def test_hawk_authentication_calls_convert_url_on_gov_paas(self, mock_convert_url):
+    @patch("conf.authentication.convert_gov_paas_url")
+    def test_hawk_authentication_calls_convert_url_on_gov_paas(self, mock_convert_gov_paas_url):
         resp = self.client.get(self.test_url)
-        mock_convert_url.assert_called_with(resp.wsgi_request.build_absolute_uri())
+        mock_convert_gov_paas_url.assert_called_with(resp.wsgi_request.build_absolute_uri())
 
-    def test_convert_url(self):
-        assert convert_url("http") == "https"
+    def test_convert_gov_paas_url(self):
+        resp = self.client.get(self.test_url)
+        assert convert_gov_paas_url(resp.wsgi_request.build_absolute_uri()) == "https://testserver/mail/licence/"


### PR DESCRIPTION
On DBT Platform there is a URL mismatch between the HMRC and API apps which causes a hawk auth failure on the HMRC side.  There is an unusual piece of code which replaces http with https which causes the Message Authentication Code to change which appears to have been a hack to get the auth to work correctly on gov paas.

Once this is removed the systems communicate normally but this change must be backwards compatible with Gov Paas.

Deployed on dev data environment for testing and some short testing notes are included on the ticket

[LTD-5751](https://uktrade.atlassian.net/browse/LTD-5751)

[LTD-5751]: https://uktrade.atlassian.net/browse/LTD-5751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ