### PR TITLE
LTD-5853 unidecode before textwrapping

### DIFF
--- a/mail/libraries/builders.py
+++ b/mail/libraries/builders.py
@@ -254,7 +254,6 @@ def build_email_message(email_message_dto: EmailMessageDto) -> MIMEMultipart:
             email_message_dto.attachment[1],
             file,
         )
-
     multipart_msg = MIMEMultipart()
     multipart_msg["From"] = settings.EMAIL_USER  # the SMTP server only allows sending as itself
     multipart_msg["To"] = email_message_dto.receiver

--- a/mail/libraries/edifact_validator.py
+++ b/mail/libraries/edifact_validator.py
@@ -180,6 +180,7 @@ def validate_foreign_trader(record):
         errors.append({record_type: f"Foreign trader name ({name}) cannot exceed {FOREIGN_TRADER_NAME_MAX_LEN} chars"})
 
     for index, line in enumerate(tokens[3:8], start=1):
+
         if len(line) > FOREIGN_TRADER_ADDR_LINE_MAX_LEN:
             errors.append(
                 {record_type: f"Address line_{index} ({line}) trader exceeds {FOREIGN_TRADER_ADDR_LINE_MAX_LEN} chars"}

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -5,6 +5,7 @@ import textwrap
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 from django.utils import timezone
+from unidecode import unidecode
 
 from mail.enums import (
     LITE_HMRC_LICENCE_TYPE_MAPPING,
@@ -247,7 +248,7 @@ def sanitize_foreign_trader_address(trader):
     addr_line = addr_line.replace("\n", " ").replace("\r", " ")
     # replace special characters
     addr_line = addr_line.replace("#", "")
-    addr_lines = textwrap.wrap(addr_line, width=FOREIGN_TRADER_ADDR_LINE_MAX_LEN, break_long_words=False)
+    addr_lines = textwrap.wrap(unidecode(addr_line), width=FOREIGN_TRADER_ADDR_LINE_MAX_LEN, break_long_words=False)
     if len(addr_lines) > FOREIGN_TRADER_NUM_ADDR_LINES:
         addr_lines = addr_lines[:FOREIGN_TRADER_NUM_ADDR_LINES]
 
@@ -270,7 +271,7 @@ def sanitize_trader_address(trader):
     addr_line = addr_line.replace("\n", " ").replace("\r", " ")
     # replace special characters
     addr_line = addr_line.replace("#", "")
-    addr_lines = textwrap.wrap(addr_line, width=FOREIGN_TRADER_ADDR_LINE_MAX_LEN, break_long_words=False)
+    addr_lines = textwrap.wrap(unidecode(addr_line), width=FOREIGN_TRADER_ADDR_LINE_MAX_LEN, break_long_words=False)
     if len(addr_lines) > FOREIGN_TRADER_NUM_ADDR_LINES:
         addr_lines = addr_lines[:FOREIGN_TRADER_NUM_ADDR_LINES]
         logging.info(

--- a/mail/tests/files/licence_payload_file_special_characters
+++ b/mail/tests/files/licence_payload_file_special_characters
@@ -1,0 +1,95 @@
+{
+  "licence": {
+    "id": "09e21356-9e9d-418d-bd4d-9792333e8cc8",
+    "reference": "GBSIEL/2024/0001234/P",
+    "type": "siel",
+    "action": "insert",
+    "start_date": "2020-06-02",
+    "end_date": "2029-06-02",
+    "organisation": {
+      "name": "Organisation",
+      "id": "10a21d56-9e9d-333d-77c5-479bb3de7ac9",
+      "eori_number": "GB123456789000",
+      "address": {
+        "line_1": "might",
+        "line_2": "248 James Key Apt. 515",
+        "line_3": "Apt. 942",
+        "line_4": "West Ashleyton",
+        "line_5": "Farnborough",
+        "postcode": "GU40 2LX",
+        "country": {
+          "id": "GB",
+          "name": "United Kingdom"
+        }
+      }
+    },
+    "end_user": {
+      "name": "AgriTrade ",
+      "address": {
+        "line_1": "Lorem ipsum dolor sit amet, consectetur adipiscing elit° Aenean ac congue massa. Aliquam dolor sem, viverra nec porta nec, egestas at elit. Proin eget ante erat.",
+        "country": {
+          "id": "BR",
+          "name": "Brazil"
+        }
+      }
+    },
+    "goods": [
+      {
+        "id": "f95ded2a-354f-46f1-a572-c7f97d63bed1",
+        "name": "Sporting shotgun",
+        "description": "",
+        "unit": "NAR",
+        "quantity": 10
+      },
+      {
+        "id": "f95ded2a-354f-46f1-a572-c7f97d63bed2",
+        "name": "Stock",
+        "description": "",
+        "unit": "MGM",
+        "quantity": 11
+      },
+      {
+        "id": "f95ded2a-354f-46f1-a572-c7f97d63bed3",
+        "name": "Metal",
+        "description": "",
+        "unit": "TON",
+        "quantity": 1
+      },
+      {
+        "id": "f95ded2a-354f-46f1-a572-c7f97d63bed4",
+        "name": "Chemical",
+        "description": "",
+        "unit": "MCG",
+        "quantity": 20
+      },
+      {
+        "id": "f95ded2a-354f-46f1-a572-c7f97d63bed5",
+        "name": "Chemical",
+        "description": "",
+        "unit": "MCL",
+        "quantity": 20
+      },
+      {
+        "id": "f95ded2a-354f-46f1-a572-c7f97d63bed6",
+        "name": "Chemical",
+        "description": "",
+        "unit": "MLT",
+        "quantity": 20
+      },
+      {
+        "id": "f95ded2a-354f-46f1-a572-c7f97d63bed7",
+        "name": "Old Chemical",
+        "description": "",
+        "unit": "MIM",
+        "quantity": 20
+      },
+      {
+        "id": "b642b709-36c7-4010-8e43-e7b8813fbde9",
+        "name": "A bottle of water",
+        "description": "",
+        "unit": "LTR",
+        "quantity": 1
+      }
+    ]
+  }
+}

--- a/mail/tests/test_edifact_validator.py
+++ b/mail/tests/test_edifact_validator.py
@@ -103,6 +103,10 @@ class LicenceToEdifactValidationTests(unittest.TestCase):
                 "5\\foreignTrader\\Advanced Firearms Limited\\50 Industrial Estate Very long\\address line_2 exceeding 35 chars\\Very long address line_3 exceeding\\35 chars Queensland NSW 42551\\\\123456789\\GBR",
                 2,
             ),
+            (
+                "5\\foreignTrader\\AgriTrade \\Lorem ipsum dolor sit amet,\\consectetur adipiscing elit° Aenean\\ac congue massa. Aliquam dolor sem,\\viverra nec porta nec, egestas at\\elit. Proin eget ante erat.\\\\BR",
+                0,
+            ),
         ]
     )
     def test_foreign_trader_validation(self, line, num_errors):

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -235,6 +235,14 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
                 "MIDDLESEX",
                 "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\this is short address BIGMAM MANOR\\NEW TESCO LANE HARROW MIDDLESEX\\NEW TESCO LANE\\HARROW\\MIDDLESEX\\GU40 2LX",
             ),
+            (
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit° Aenean ac congue massa. Aliquam dolor sem, viverra nec porta nec, egestas at elit. Proin eget ante erat.",
+                "",
+                "",
+                "",
+                "",
+                "3\\trader\\\\GB123456789000\\20200602\\20220602\\Advanced Firearms Limited\\Lorem ipsum dolor sit amet,\\consectetur adipiscing elitdeg\\Aenean ac congue massa. Aliquam\\dolor sem, viverra nec porta nec,\\egestas at elit. Proin eget ante\\GU40 2LX",
+            ),
         ]
     )
     def test_trader_address_sanitize(


### PR DESCRIPTION
**Issue:**
* hmrc requires a length of 35 per address line
* lite-hmrc achieved this using textwrap
* unidecode appended to the character count and we managed to go over


**Things to note:**
I had initially added the unidecode to edifact_validators so that the validator could catch the error and went back and forth with this idea for a little while, in theory because it's decoded now in the sanitizer (lite_to_edifact_converter) it will never hit the sanitizer with special characters present.
I have also added some coverage tests in test_builder so that we cant remove this and accidentally have things pass. 
if we notice any other edge cases we could update the new payload file to include them

[LTD-5853](https://uktrade.atlassian.net/browse/LTD-5853)

[LTD-5853]: https://uktrade.atlassian.net/browse/LTD-5853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ