### PR TITLE
Update licence data serializers

### DIFF
--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -199,7 +199,6 @@ class LiteGenericLicenceDataSerializer(serializers.Serializer):
             pass
         else:
             action = self.initial_data.get("action")
-            type_ = self.initial_data.get("type")
 
             if action == enums.LicenceActionEnum.UPDATE:
                 self.fields["old_id"].required = True

--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -174,7 +174,7 @@ class ForeignTraderSerializer(serializers.Serializer):
     address = AddressSerializer()
 
 
-class LiteLicenceDataSerializer(serializers.Serializer):
+class LiteGenericLicenceDataSerializer(serializers.Serializer):
     id = serializers.CharField()
     reference = serializers.CharField(max_length=35)
     type = serializers.CharField()
@@ -204,10 +204,6 @@ class LiteLicenceDataSerializer(serializers.Serializer):
             if action == enums.LicenceActionEnum.UPDATE:
                 self.fields["old_id"].required = True
 
-            if type_ in enums.LicenceTypeEnum.OPEN_LICENCES + enums.LicenceTypeEnum.OPEN_GENERAL_LICENCES:
-                self.fields["countries"].required = True
-                self.fields["countries"].min_length = 1
-
         return super().is_valid(*args, **kwargs)
 
     def validate_old_id(self, value):
@@ -219,9 +215,15 @@ class LiteLicenceDataSerializer(serializers.Serializer):
         return value
 
 
-class LiteStandardLicenceDataSerializer(LiteLicenceDataSerializer):
+class LiteStandardIndividualExportLicenceDataSerializer(LiteGenericLicenceDataSerializer):
+    # LITE SIEL Licence Data Serializer
     end_user = ForeignTraderSerializer(required=True, allow_null=False)
     goods = GoodSerializer(many=True, required=True, allow_null=False)
+
+
+class LiteOpenIndividualExportLicenceDataSerializer(LiteGenericLicenceDataSerializer):
+    # LITE OIEL Licence Data Serializer
+    countries = CountrySerializer(many=True, required=True, min_length=1)
 
 
 class LicenceDataStatusSerializer(serializers.ModelSerializer):

--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -174,7 +174,7 @@ class ForeignTraderSerializer(serializers.Serializer):
     address = AddressSerializer()
 
 
-class LiteGenericLicenceDataSerializer(serializers.Serializer):
+class _LiteGenericLicenceDataSerializer(serializers.Serializer):
     id = serializers.CharField()
     reference = serializers.CharField(max_length=35)
     type = serializers.CharField()
@@ -214,13 +214,13 @@ class LiteGenericLicenceDataSerializer(serializers.Serializer):
         return value
 
 
-class LiteStandardIndividualExportLicenceDataSerializer(LiteGenericLicenceDataSerializer):
+class LiteStandardIndividualExportLicenceDataSerializer(_LiteGenericLicenceDataSerializer):
     # LITE SIEL Licence Data Serializer
     end_user = ForeignTraderSerializer(required=True, allow_null=False)
     goods = GoodSerializer(many=True, required=True, allow_null=False)
 
 
-class LiteOpenIndividualExportLicenceDataSerializer(LiteGenericLicenceDataSerializer):
+class LiteOpenIndividualExportLicenceDataSerializer(_LiteGenericLicenceDataSerializer):
     # LITE OIEL Licence Data Serializer
     countries = CountrySerializer(many=True, required=True, min_length=1)
 

--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -184,7 +184,7 @@ class _LiteGenericLicenceDataSerializer(serializers.Serializer):
 
     old_id = serializers.CharField(required=False)
 
-    # These fields depend on the submitted licence `type`.
+    # These fields are required depending on the submitted licence `type`.
     countries = CountrySerializer(many=True, required=False)
     end_user = ForeignTraderSerializer(required=False, allow_null=True)
     goods = GoodSerializer(many=True, required=False, allow_null=True)

--- a/mail/serializers.py
+++ b/mail/serializers.py
@@ -208,12 +208,6 @@ class LiteLicenceDataSerializer(serializers.Serializer):
                 self.fields["countries"].required = True
                 self.fields["countries"].min_length = 1
 
-            if type_ in enums.LicenceTypeEnum.STANDARD_LICENCES:
-                self.fields["end_user"].required = True
-                self.fields["end_user"].allow_null = False
-                self.fields["goods"].required = True
-                self.fields["goods"].allow_null = False
-
         return super().is_valid(*args, **kwargs)
 
     def validate_old_id(self, value):
@@ -223,6 +217,11 @@ class LiteLicenceDataSerializer(serializers.Serializer):
         ):
             raise serializers.ValidationError("This licence does not exist in HMRC integration records")
         return value
+
+
+class LiteStandardLicenceDataSerializer(LiteLicenceDataSerializer):
+    end_user = ForeignTraderSerializer(required=True, allow_null=False)
+    goods = GoodSerializer(many=True, required=True, allow_null=False)
 
 
 class LicenceDataStatusSerializer(serializers.ModelSerializer):

--- a/mail/tests/test_serializers.py
+++ b/mail/tests/test_serializers.py
@@ -6,12 +6,16 @@ from rest_framework.exceptions import ErrorDetail
 
 from mail import icms_serializers
 from mail.enums import ChiefSystemEnum, LicenceTypeEnum, UnitMapping
-from mail.serializers import LiteLicenceDataSerializer, LiteStandardLicenceDataSerializer
+from mail.serializers import (
+    LiteGenericLicenceDataSerializer,
+    LiteOpenIndividualExportLicenceDataSerializer,
+    LiteStandardIndividualExportLicenceDataSerializer,
+)
 
 
 class LiteLicenceDataSerializerTestCase(TestCase):
     def test_no_data(self):
-        serializer = LiteLicenceDataSerializer(data={})
+        serializer = LiteGenericLicenceDataSerializer(data={})
 
         self.assertFalse(serializer.is_valid())
         expected_errors = {
@@ -33,7 +37,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
             "start_date": "1999-12-31",
             "type": "baz",
         }
-        serializer = LiteLicenceDataSerializer(data=data)
+        serializer = LiteGenericLicenceDataSerializer(data=data)
 
         self.assertFalse(serializer.is_valid())
         expected_errors = {
@@ -53,7 +57,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
             "start_date": "1999-12-31",
             "type": "baz",
         }
-        serializer = LiteLicenceDataSerializer(data=data)
+        serializer = LiteGenericLicenceDataSerializer(data=data)
 
         self.assertFalse(serializer.is_valid())
         expected_errors = {
@@ -72,7 +76,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
                     "start_date": "1999-12-31",
                     "type": type_,
                 }
-                serializer = LiteLicenceDataSerializer(data=data)
+                serializer = LiteOpenIndividualExportLicenceDataSerializer(data=data)
 
                 self.assertFalse(serializer.is_valid())
 
@@ -92,7 +96,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
                     "start_date": "1999-12-31",
                     "type": type_,
                 }
-                serializer = LiteStandardLicenceDataSerializer(data=data)
+                serializer = LiteStandardIndividualExportLicenceDataSerializer(data=data)
 
                 self.assertFalse(serializer.is_valid())
 
@@ -114,7 +118,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
             "type": LicenceTypeEnum.OPEN_LICENCES[0],
             "countries": [],
         }
-        serializer = LiteLicenceDataSerializer(data=data)
+        serializer = LiteOpenIndividualExportLicenceDataSerializer(data=data)
 
         self.assertFalse(serializer.is_valid())
         expected_errors = {
@@ -139,7 +143,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
                 }
             ],
         }
-        serializer = LiteLicenceDataSerializer(data=data)
+        serializer = LiteOpenIndividualExportLicenceDataSerializer(data=data)
 
         self.assertTrue(serializer.is_valid())
 
@@ -168,7 +172,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
                 },
             ],
         }
-        serializer = LiteLicenceDataSerializer(data=data)
+        serializer = LiteGenericLicenceDataSerializer(data=data)
         serializer.is_valid()
 
         expected_errors = {
@@ -208,7 +212,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
             # `unit_label` is each of the strings, like "NAR", "ITG", etc.
             with self.subTest(unit=unit_label):
                 data["goods"][0]["unit"] = unit_label
-                serializer = LiteLicenceDataSerializer(data=data)
+                serializer = LiteGenericLicenceDataSerializer(data=data)
                 is_valid = serializer.is_valid()
 
                 self.assertDictEqual(serializer.errors, {})

--- a/mail/tests/test_serializers.py
+++ b/mail/tests/test_serializers.py
@@ -96,27 +96,6 @@ class LiteStandardIndividualExportLicenceDataSerializerTestCase(TestCase):
         }
         self.assertDictEqual(serializer.errors, expected_errors)
 
-    def test_required_fields_for_standard_type(self):
-        for type_ in LicenceTypeEnum.STANDARD_LICENCES:
-            with self.subTest(type_=type_):
-                data = {
-                    "action": "insert",
-                    "end_date": "1999-12-31",
-                    "id": "foo",
-                    "reference": "bar",
-                    "start_date": "1999-12-31",
-                    "type": type_,
-                }
-                serializer = LiteStandardIndividualExportLicenceDataSerializer(data=data)
-
-                self.assertFalse(serializer.is_valid())
-
-                expected_errors = {
-                    "end_user": ["This field is required."],
-                    "goods": ["This field is required."],
-                }
-                self.assertDictEqual(serializer.errors, expected_errors)
-
     def test_goods_invalid_choice_for_unit(self):
         data = {
             "action": "insert",

--- a/mail/tests/test_serializers.py
+++ b/mail/tests/test_serializers.py
@@ -32,10 +32,10 @@ class LiteStandardIndividualExportLicenceDataSerializerTestCase(TestCase):
     def test_old_id_required_when_action_is_update(self):
         data = {
             "action": "update",
-            "end_date": "1999-12-31",
+            "end_date": "2027-01-01",
             "id": "foo",
             "reference": "bar",
-            "start_date": "1999-12-31",
+            "start_date": "2025-01-01",
             "type": "siel",
             "end_user": {
                 "name": "Foo",
@@ -64,13 +64,13 @@ class LiteStandardIndividualExportLicenceDataSerializerTestCase(TestCase):
     def test_invalid_old_id_when_action_is_update(self):
         data = {
             "action": "update",
-            "end_date": "1999-12-31",
+            "end_date": "2027-01-01",
             "id": "foo",
             # This is a valid UUID-format key, but there is no matching
             # record in the database.
             "old_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "reference": "bar",
-            "start_date": "1999-12-31",
+            "start_date": "2025-01-01",
             "type": "siel",
             "end_user": {
                 "name": "Foo",
@@ -99,10 +99,10 @@ class LiteStandardIndividualExportLicenceDataSerializerTestCase(TestCase):
     def test_goods_invalid_choice_for_unit(self):
         data = {
             "action": "insert",
-            "end_date": "1999-12-31",
+            "end_date": "2027-01-01",
             "id": "foo",
             "reference": "bar",
-            "start_date": "1999-12-31",
+            "start_date": "2025-01-01",
             "type": "siel",  # Standard type, which requires "goods".
             "end_user": {
                 "name": "Foo",
@@ -134,10 +134,10 @@ class LiteStandardIndividualExportLicenceDataSerializerTestCase(TestCase):
     def test_goods_valid_choice_for_unit(self):
         data = {
             "action": "insert",
-            "end_date": "1999-12-31",
+            "end_date": "2027-01-01",
             "id": "foo",
             "reference": "bar",
-            "start_date": "1999-12-31",
+            "start_date": "2025-01-01",
             "type": "siel",  # Standard type, which requires "goods".
             "end_user": {
                 "name": "Foo",
@@ -172,10 +172,10 @@ class LiteOpenIndividualExportLicenceDataSerializerTestCase(TestCase):
     def test_required_fields_for_oiel_type(self):
         data = {
             "action": "insert",
-            "end_date": "1999-12-31",
+            "end_date": "2030-01-01",
             "id": "foo",
             "reference": "bar",
-            "start_date": "1999-12-31",
+            "start_date": "2025-01-01",
             "type": "oiel",
         }
         serializer = LiteOpenIndividualExportLicenceDataSerializer(data=data)
@@ -192,10 +192,10 @@ class LiteOpenIndividualExportLicenceDataSerializerTestCase(TestCase):
         # country item.
         data = {
             "action": "insert",
-            "end_date": "1999-12-31",
+            "end_date": "2030-01-01",
             "id": "foo",
             "reference": "bar",
-            "start_date": "1999-12-31",
+            "start_date": "2025-01-01",
             "type": "oiel",
             "countries": [],
         }
@@ -212,10 +212,10 @@ class LiteOpenIndividualExportLicenceDataSerializerTestCase(TestCase):
     def test_valid_countries_for_oiel_type(self):
         data = {
             "action": "insert",
-            "end_date": "1999-12-31",
+            "end_date": "2030-01-01",
             "id": "foo",
             "reference": "bar",
-            "start_date": "1999-12-31",
+            "start_date": "2025-01-01",
             "type": "oiel",
             "countries": [
                 {

--- a/mail/tests/test_serializers.py
+++ b/mail/tests/test_serializers.py
@@ -5,7 +5,7 @@ from parameterized import parameterized
 from rest_framework.exceptions import ErrorDetail
 
 from mail import icms_serializers
-from mail.enums import ChiefSystemEnum, LicenceTypeEnum, UnitMapping
+from mail.enums import ChiefSystemEnum, UnitMapping
 from mail.serializers import (
     LiteOpenIndividualExportLicenceDataSerializer,
     LiteStandardIndividualExportLicenceDataSerializer,
@@ -169,28 +169,26 @@ class LiteStandardIndividualExportLicenceDataSerializerTestCase(TestCase):
 
 
 class LiteOpenIndividualExportLicenceDataSerializerTestCase(TestCase):
-    def test_required_fields_for_open_or_general_type(self):
-        for type_ in LicenceTypeEnum.OPEN_LICENCES + LicenceTypeEnum.OPEN_GENERAL_LICENCES:
-            with self.subTest(type_=type_):
-                data = {
-                    "action": "insert",
-                    "end_date": "1999-12-31",
-                    "id": "foo",
-                    "reference": "bar",
-                    "start_date": "1999-12-31",
-                    "type": type_,
-                }
-                serializer = LiteOpenIndividualExportLicenceDataSerializer(data=data)
+    def test_required_fields_for_oiel_type(self):
+        data = {
+            "action": "insert",
+            "end_date": "1999-12-31",
+            "id": "foo",
+            "reference": "bar",
+            "start_date": "1999-12-31",
+            "type": "oiel",
+        }
+        serializer = LiteOpenIndividualExportLicenceDataSerializer(data=data)
 
-                self.assertFalse(serializer.is_valid())
+        self.assertFalse(serializer.is_valid())
 
-                expected_errors = {
-                    "countries": ["This field is required."],
-                }
-                self.assertDictEqual(serializer.errors, expected_errors)
+        expected_errors = {
+            "countries": ["This field is required."],
+        }
+        self.assertDictEqual(serializer.errors, expected_errors)
 
-    def test_minimum_countries_for_open_type(self):
-        # For open licence types, the request data must include at least 1
+    def test_minimum_countries_for_oiel_type(self):
+        # For the oiel licence type, the request data must include at least 1
         # country item.
         data = {
             "action": "insert",
@@ -198,7 +196,7 @@ class LiteOpenIndividualExportLicenceDataSerializerTestCase(TestCase):
             "id": "foo",
             "reference": "bar",
             "start_date": "1999-12-31",
-            "type": LicenceTypeEnum.OPEN_LICENCES[0],
+            "type": "oiel",
             "countries": [],
         }
         serializer = LiteOpenIndividualExportLicenceDataSerializer(data=data)
@@ -211,14 +209,14 @@ class LiteOpenIndividualExportLicenceDataSerializerTestCase(TestCase):
         }
         self.assertDictEqual(serializer.errors, expected_errors)
 
-    def test_valid_countries_for_open_type(self):
+    def test_valid_countries_for_oiel_type(self):
         data = {
             "action": "insert",
             "end_date": "1999-12-31",
             "id": "foo",
             "reference": "bar",
             "start_date": "1999-12-31",
-            "type": LicenceTypeEnum.OPEN_LICENCES[0],
+            "type": "oiel",
             "countries": [
                 {
                     "id": "GB",

--- a/mail/tests/test_serializers.py
+++ b/mail/tests/test_serializers.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ErrorDetail
 
 from mail import icms_serializers
 from mail.enums import ChiefSystemEnum, LicenceTypeEnum, UnitMapping
-from mail.serializers import LiteLicenceDataSerializer
+from mail.serializers import LiteLicenceDataSerializer, LiteStandardLicenceDataSerializer
 
 
 class LiteLicenceDataSerializerTestCase(TestCase):
@@ -92,7 +92,7 @@ class LiteLicenceDataSerializerTestCase(TestCase):
                     "start_date": "1999-12-31",
                     "type": type_,
                 }
-                serializer = LiteLicenceDataSerializer(data=data)
+                serializer = LiteStandardLicenceDataSerializer(data=data)
 
                 self.assertFalse(serializer.is_valid())
 
@@ -498,7 +498,7 @@ def get_valid_fa_sil_payload():
                 "line_3": "line_3",
                 "line_4": "",
                 "line_5": "",
-                "postcode": "S227ZZ",
+                "postcode": "S227ZZ",  # /PS-IGNORE
             },
         },
         "country_code": "US",
@@ -531,7 +531,7 @@ def get_valid_sanctions_payload():
                 "line_3": "line_3",
                 "line_4": "",
                 "line_5": "",
-                "postcode": "S227ZZ",
+                "postcode": "S227ZZ",  # /PS-IGNORE
             },
         },
         "country_code": "RU",

--- a/mail/tests/test_update_licence_endpoint.py
+++ b/mail/tests/test_update_licence_endpoint.py
@@ -95,3 +95,9 @@ class UpdateLicenceEndpointTests(LiteHMRCTestClient):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(LicencePayload.objects.count(), initial_licence_count)
         self.assertEqual(LicenceIdMapping.objects.count(), initial_licence_id_mapping_count)
+
+    def test_post_data_failure_app_type_not_supported(self):
+        data = self.licence_payload_json
+        data["licence"]["type"] = "notavalidtype"
+        with self.assertRaises(NotImplementedError):
+            self.client.post(self.url, data=data, content_type="application/json")

--- a/mail/views.py
+++ b/mail/views.py
@@ -9,7 +9,11 @@ from conf.authentication import HawkOnlyAuthentication
 from mail.celery_tasks import send_licence_details_to_hmrc
 from mail.enums import LicenceActionEnum, LicenceTypeEnum, ReceptionStatusEnum
 from mail.models import LicenceData, LicenceIdMapping, LicencePayload, Mail
-from mail.serializers import LiteLicenceDataSerializer, LiteStandardLicenceDataSerializer, MailSerializer
+from mail.serializers import (
+    LiteOpenIndividualExportLicenceDataSerializer,
+    LiteStandardIndividualExportLicenceDataSerializer,
+    MailSerializer,
+)
 
 if TYPE_CHECKING:
     from rest_framework.serializers import Serializer  # noqa
@@ -74,11 +78,13 @@ class LicenceDataIngestView(APIView):
         )
 
     def get_serializer_cls(self, app_type: str) -> Type["Serializer"]:
-        app_type_to_serializer = {str(LicenceTypeEnum.SIEL): LiteStandardLicenceDataSerializer}
+        app_type_to_serializer = {
+            str(LicenceTypeEnum.SIEL): LiteStandardIndividualExportLicenceDataSerializer,
+            str(LicenceTypeEnum.OIEL): LiteOpenIndividualExportLicenceDataSerializer,
+        }
         if app_type in app_type_to_serializer.keys():
             serializer = app_type_to_serializer[app_type]
             return serializer
-        return LiteLicenceDataSerializer
 
 
 class SendLicenceUpdatesToHmrc(APIView):

--- a/mail/views.py
+++ b/mail/views.py
@@ -85,6 +85,7 @@ class LicenceDataIngestView(APIView):
         if app_type in app_type_to_serializer.keys():
             serializer = app_type_to_serializer[app_type]
             return serializer
+        raise NotImplementedError(f"Application type {app_type} not supported.")
 
 
 class SendLicenceUpdatesToHmrc(APIView):

--- a/mail/views.py
+++ b/mail/views.py
@@ -7,9 +7,9 @@ from rest_framework.views import APIView
 
 from conf.authentication import HawkOnlyAuthentication
 from mail.celery_tasks import send_licence_details_to_hmrc
-from mail.enums import LicenceActionEnum, ReceptionStatusEnum
+from mail.enums import LicenceActionEnum, LicenceTypeEnum, ReceptionStatusEnum
 from mail.models import LicenceData, LicenceIdMapping, LicencePayload, Mail
-from mail.serializers import LiteLicenceDataSerializer, MailSerializer
+from mail.serializers import LiteLicenceDataSerializer, LiteStandardLicenceDataSerializer, MailSerializer
 
 if TYPE_CHECKING:
     from rest_framework.serializers import Serializer  # noqa
@@ -74,6 +74,10 @@ class LicenceDataIngestView(APIView):
         )
 
     def get_serializer_cls(self, app_type: str) -> Type["Serializer"]:
+        app_type_to_serializer = {str(LicenceTypeEnum.SIEL): LiteStandardLicenceDataSerializer}
+        if app_type in app_type_to_serializer.keys():
+            serializer = app_type_to_serializer[app_type]
+            return serializer
         return LiteLicenceDataSerializer
 
 

--- a/mail/views.py
+++ b/mail/views.py
@@ -1,15 +1,13 @@
 import logging
 from typing import TYPE_CHECKING, Type
 
-from django.conf import settings
 from django.http import JsonResponse
 from rest_framework import status
 from rest_framework.views import APIView
 
 from conf.authentication import HawkOnlyAuthentication
-from mail import icms_serializers
 from mail.celery_tasks import send_licence_details_to_hmrc
-from mail.enums import ChiefSystemEnum, LicenceActionEnum, LicenceTypeEnum, ReceptionStatusEnum
+from mail.enums import LicenceActionEnum, ReceptionStatusEnum
 from mail.models import LicenceData, LicenceIdMapping, LicencePayload, Mail
 from mail.serializers import LiteLicenceDataSerializer, MailSerializer
 
@@ -76,16 +74,6 @@ class LicenceDataIngestView(APIView):
         )
 
     def get_serializer_cls(self, app_type: str) -> Type["Serializer"]:
-        if settings.CHIEF_SOURCE_SYSTEM == ChiefSystemEnum.ICMS:
-            serializers = {
-                LicenceTypeEnum.IMPORT_OIL: icms_serializers.FirearmOilLicenceDataSerializer,
-                LicenceTypeEnum.IMPORT_DFL: icms_serializers.FirearmDflLicenceDataSerializer,
-                LicenceTypeEnum.IMPORT_SIL: icms_serializers.FirearmSilLicenceDataSerializer,
-                LicenceTypeEnum.IMPORT_SAN: icms_serializers.SanctionLicenceDataSerializer,
-            }
-
-            return serializers[app_type]
-
         return LiteLicenceDataSerializer
 
 


### PR DESCRIPTION
This change preserves the exact logic for required fields etc that we had before, it just refactors the code so instead of if-statements we have separate serializers and a mapping between specific licence types and specific serializers.

The tests have also been updated so we are testing specific serializers instead of that generic serializer.

Also added a test for the new NotImplementedError.

[LTD-6174](https://uktrade.atlassian.net/browse/LTD-6174)

[LTD-6174]: https://uktrade.atlassian.net/browse/LTD-6174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ