### PR TITLE
Update lite_to_edifact_converter

### DIFF
--- a/mail/libraries/edifact_validator.py
+++ b/mail/libraries/edifact_validator.py
@@ -231,7 +231,7 @@ def validate_licence_product_line(record):
     # Use chief type rather than indexing into tokens
     ld = chieftypes.LicenceDataLine(*tokens)
 
-    if ld.goods_description == "Open Licence goods - see actual licence for information":
+    if ld.controlled_by == "O":
         # open licence goods, skip further checks
         return errors
 

--- a/mail/libraries/edifact_validator.py
+++ b/mail/libraries/edifact_validator.py
@@ -231,6 +231,10 @@ def validate_licence_product_line(record):
     # Use chief type rather than indexing into tokens
     ld = chieftypes.LicenceDataLine(*tokens)
 
+    if ld.goods_description == "Open Licence goods - see actual licence for information":
+        # open licence goods, skip further checks
+        return errors
+
     if settings.CHIEF_SOURCE_SYSTEM == "SPIRE":
         if not ld.goods_description:
             errors.append({record_type: "Product description cannot be empty"})

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -182,7 +182,7 @@ def generate_lines_for_licence(licence: LicencePayload) -> Iterable[chieftypes._
             yield chieftypes.LicenceDataLine(
                 line_num=1,
                 goods_description="Open Licence goods - see actual licence for information",
-                controlled_by="O",
+                controlled_by=controlled_by,
             )
 
     yield chieftypes.End(start_record_type=chieftypes.Licence.type_)

--- a/mail/libraries/lite_to_edifact_converter.py
+++ b/mail/libraries/lite_to_edifact_converter.py
@@ -178,9 +178,11 @@ def generate_lines_for_licence(licence: LicencePayload) -> Iterable[chieftypes._
                 )
 
         if payload.get("type") in LicenceTypeEnum.OPEN_LICENCES:
+            controlled_by = "O"  # usage is Open (no usage recording or control)
             yield chieftypes.LicenceDataLine(
                 line_num=1,
                 goods_description="Open Licence goods - see actual licence for information",
+                controlled_by="O",
             )
 
     yield chieftypes.End(start_record_type=chieftypes.Licence.type_)

--- a/mail/tests/files/open_licence_payload_file
+++ b/mail/tests/files/open_licence_payload_file
@@ -1,0 +1,37 @@
+{
+  "licence": {
+    "id": "3de27a3e-defa-4d59-8223-947d2dc4bb00",
+    "reference": "GBOIEL/2026/0000001/P",
+    "type": "oiel",
+    "action": "insert",
+    "start_date": "2026-06-02",
+    "end_date": "2031-06-02",
+    "organisation": {
+      "name": "Organisation",
+      "id": "10a21d56-9e9d-333d-77c5-479bb3de7ac9",
+      "eori_number": "GB123456789000",
+      "address": {
+        "line_1": "might",
+        "line_2": "248 James Key Apt. 515",
+        "line_3": "Apt. 942",
+        "line_4": "West Ashleyton",
+        "line_5": "Farnborough",
+        "postcode": "GU40 2LX",
+        "country": {
+          "id": "GB",
+          "name": "United Kingdom"
+        }
+      }
+    },
+    "countries": [
+      {
+        "id": "CA",
+        "name": "Canada"
+      },
+      {
+        "id": "US",
+        "name": "United States"
+      }
+    ]
+  }
+}

--- a/mail/tests/libraries/client.py
+++ b/mail/tests/libraries/client.py
@@ -1,13 +1,10 @@
 import json
-import logging
 
 from django.test import testcases
 from django.utils import timezone
 
 from conf import settings
-from mail.enums import LicenceActionEnum
 from mail.libraries.helpers import read_file
-from mail.models import LicencePayload
 from mail.tests.libraries import colours
 
 
@@ -37,11 +34,8 @@ class LiteHMRCTestClient(testcases.TestCase):
 
         self.licence_payload_json = json.loads(read_file("mail/tests/files/licence_payload_file", encoding="utf-8"))
 
-        self.single_siel_licence_payload = LicencePayload.objects.create(
-            lite_id=self.licence_payload_json["licence"]["id"],
-            reference=self.licence_payload_json["licence"]["reference"],
-            data=self.licence_payload_json["licence"],
-            action=LicenceActionEnum.INSERT,
+        self.open_licence_payload_json = json.loads(
+            read_file("mail/tests/files/open_licence_payload_file", encoding="utf-8")
         )
 
     def tearDown(self):

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -18,6 +18,15 @@ from mail.tests.libraries.client import LiteHMRCTestClient
 
 
 class StandardLicenceToEdifactTests(LiteHMRCTestClient):
+    def setUp(self):
+        super().setUp()
+        self.single_siel_licence_payload = LicencePayload.objects.create(
+            lite_id=self.licence_payload_json["licence"]["id"],
+            reference=self.licence_payload_json["licence"]["reference"],
+            data=self.licence_payload_json["licence"],
+            action=LicenceActionEnum.INSERT,
+        )
+
     def test_mappings(self):
         licence = LicencePayload.objects.get()
         licence.data["type"] = "siel"
@@ -355,6 +364,17 @@ class StandardLicenceToEdifactTests(LiteHMRCTestClient):
         edifact_file = licences_to_edifact(licences, 1234, "FOO")
         trader_line = edifact_file.split("\n")[2]
         self.assertEqual(trader_line, expected_trader_line)
+
+
+class OpenLicenceToEdifactTests(LiteHMRCTestClient):
+    def setUp(self):
+        super().setUp()
+        self.single_oiel_licence_payload = LicencePayload.objects.create(
+            lite_id=self.open_licence_payload_json["licence"]["id"],
+            reference=self.open_licence_payload_json["licence"]["reference"],
+            data=self.open_licence_payload_json["licence"],
+            action=LicenceActionEnum.INSERT,
+        )
 
 
 class GenerateLinesForOpenLicenceTest(LiteHMRCTestClient):

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -18,10 +18,9 @@ from mail.tests.libraries.client import LiteHMRCTestClient
 
 
 class LicenceToEdifactTests(LiteHMRCTestClient):
-    @parameterized.expand(["siel", "sitl", "sicl"])
-    def test_mappings(self, licence_type):
+    def test_mappings(self):
         licence = LicencePayload.objects.get()
-        licence.data["type"] = licence_type
+        licence.data["type"] = "siel"
         licence.save()
         organisation_id = licence.data["organisation"]["id"]
         good_id = licence.data["goods"][0]["id"]

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -391,7 +391,7 @@ class OpenLicenceToEdifactTests(LiteHMRCTestClient):
             + "\n4\\country\\CA\\\\D"
             + "\n5\\country\\US\\\\D"
             + "\n6\\restrictions\\Provisos may apply please see licence"
-            + "\n7\\line\\1\\\\\\\\\\Open Licence goods - see actual licence for information\\\\\\\\\\\\\\\\\\\\\\"
+            + "\n7\\line\\1\\\\\\\\\\Open Licence goods - see actual licence for information\\O\\\\\\\\\\\\\\\\\\\\"
             + "\n8\\end\\licence\\7"
             + "\n9\\fileTrailer\\1\n"
         )

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -17,7 +17,7 @@ from mail.models import GoodIdMapping, LicencePayload, Mail
 from mail.tests.libraries.client import LiteHMRCTestClient
 
 
-class LicenceToEdifactTests(LiteHMRCTestClient):
+class StandardLicenceToEdifactTests(LiteHMRCTestClient):
     def test_mappings(self):
         licence = LicencePayload.objects.get()
         licence.data["type"] = "siel"
@@ -357,7 +357,7 @@ class LicenceToEdifactTests(LiteHMRCTestClient):
         self.assertEqual(trader_line, expected_trader_line)
 
 
-class GenerateLinesForLicenceTest(LiteHMRCTestClient):
+class GenerateLinesForOpenLicenceTest(LiteHMRCTestClient):
     def test_open_licence_with_country_group(self):
         data = {
             "start_date": "1",
@@ -369,7 +369,7 @@ class GenerateLinesForLicenceTest(LiteHMRCTestClient):
             "type": "oiel",  # One of the OPEN_LICENCES.
             "country_group": "G012",  # This example is from an ICMS message.
         }
-        licence = LicencePayload(reference="GBSIEL/123", data=data)
+        licence = LicencePayload(reference="GBOIEL/123", data=data)
         lines = list(generate_lines_for_licence(licence))
 
         expected_types = ["licence", "trader", "country", "restrictions", "line", "end"]
@@ -388,7 +388,7 @@ class GenerateLinesForLicenceTest(LiteHMRCTestClient):
             "type": "oiel",  # One of the OPEN_LICENCES.
             "countries": [{"id": "GB"}, {"id": "NI"}],
         }
-        licence = LicencePayload(reference="GBSIEL/123", data=data)
+        licence = LicencePayload(reference="GBOIEL/123", data=data)
         lines = list(generate_lines_for_licence(licence))
 
         # Note there are 2 country lines.

--- a/mail/tests/test_licence_to_edifact.py
+++ b/mail/tests/test_licence_to_edifact.py
@@ -376,6 +376,28 @@ class OpenLicenceToEdifactTests(LiteHMRCTestClient):
             action=LicenceActionEnum.INSERT,
         )
 
+    def test_single_oiel(self):
+        licences = LicencePayload.objects.filter(is_processed=False)
+
+        result = licences_to_edifact(licences, 1234, "FOO")
+        trader = licences[0].data["organisation"]
+        now = timezone.now()
+        expected = (
+            "1\\fileHeader\\FOO\\CHIEF\\licenceData\\"
+            + "{:04d}{:02d}{:02d}{:02d}{:02d}".format(now.year, now.month, now.day, now.hour, now.minute)
+            + "\\1234\\N"
+            + "\n2\\licence\\20260000001P\\insert\\GBOIEL/2026/0000001/P\\OIE\\E\\20260602\\20310602"
+            + f"\n3\\trader\\\\{trader['eori_number']}\\20260602\\20310602\\Organisation\\might 248 James Key Apt. 515 Apt.\\942 West Ashleyton Farnborough\\Apt. 942\\West Ashleyton\\Farnborough\\GU40 2LX"
+            + "\n4\\country\\CA\\\\D"
+            + "\n5\\country\\US\\\\D"
+            + "\n6\\restrictions\\Provisos may apply please see licence"
+            + "\n7\\line\\1\\\\\\\\\\Open Licence goods - see actual licence for information\\\\\\\\\\\\\\\\\\\\\\"
+            + "\n8\\end\\licence\\7"
+            + "\n9\\fileTrailer\\1\n"
+        )
+
+        self.assertEqual(result, expected)
+
 
 class GenerateLinesForOpenLicenceTest(LiteHMRCTestClient):
     def test_open_licence_with_country_group(self):

--- a/mail/tests/test_send_lite_licence_updates_task.py
+++ b/mail/tests/test_send_lite_licence_updates_task.py
@@ -3,7 +3,7 @@ from unittest import mock
 from parameterized import parameterized
 
 from mail.celery_tasks import send_licence_details_to_hmrc
-from mail.enums import ReceptionStatusEnum
+from mail.enums import LicenceActionEnum, ReceptionStatusEnum
 from mail.libraries.lite_to_edifact_converter import EdifactValidationError
 from mail.models import LicencePayload, Mail
 from mail.tests.libraries.client import LiteHMRCTestClient
@@ -12,6 +12,12 @@ from mail.tests.libraries.client import LiteHMRCTestClient
 class SendLiteLicenceDetailsTaskTests(LiteHMRCTestClient):
     def setUp(self):
         super().setUp()
+        self.single_siel_licence_payload = LicencePayload.objects.create(
+            lite_id=self.licence_payload_json["licence"]["id"],
+            reference=self.licence_payload_json["licence"]["reference"],
+            data=self.licence_payload_json["licence"],
+            action=LicenceActionEnum.INSERT,
+        )
         self.mail = Mail.objects.create(edi_filename="filename", edi_data="1\\fileHeader\\CHIEF\\SPIRE\\")
 
     @mock.patch("mail.celery_tasks.cache")

--- a/mail/tests/test_update_licence_endpoint.py
+++ b/mail/tests/test_update_licence_endpoint.py
@@ -7,6 +7,15 @@ from mail.tests.libraries.client import LiteHMRCTestClient
 
 
 class UpdateLicenceEndpointTests(LiteHMRCTestClient):
+    def setUp(self):
+        super().setUp()
+        self.single_siel_licence_payload = LicencePayload.objects.create(
+            lite_id=self.licence_payload_json["licence"]["id"],
+            reference=self.licence_payload_json["licence"]["reference"],
+            data=self.licence_payload_json["licence"],
+            action=LicenceActionEnum.INSERT,
+        )
+
     url = reverse("mail:update_licence")
 
     def test_post_data_failure_no_data(self):

--- a/mail/tests/test_usage_data_decompostion.py
+++ b/mail/tests/test_usage_data_decompostion.py
@@ -1,6 +1,6 @@
 import uuid
 
-from mail.enums import SourceEnum
+from mail.enums import LicenceActionEnum, SourceEnum
 from mail.libraries.helpers import get_good_id, read_file
 from mail.libraries.usage_data_decomposition import (
     build_edifact_file_from_data_blocks,
@@ -15,6 +15,12 @@ from mail.tests.libraries.client import LiteHMRCTestClient
 class FileDeconstruction(LiteHMRCTestClient):
     def setUp(self):
         super().setUp()
+        self.single_siel_licence_payload = LicencePayload.objects.create(
+            lite_id=self.licence_payload_json["licence"]["id"],
+            reference=self.licence_payload_json["licence"]["reference"],
+            data=self.licence_payload_json["licence"],
+            action=LicenceActionEnum.INSERT,
+        )
 
         self.spire_data_expected = [
             ["fileHeader\\CHIEF\\SPIRE\\usageData\\201901130300\\49543\\"],

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -15,6 +15,7 @@ mail/tests/test_send_licence_usage_figures_to_lite_api.py
 mail/tests/test_licence_to_edifact.py
 mail/tests/test_select_email_for_sending.py
 mail/tests/files/licence_payload_file
+mail/tests/files/open_licence_payload_file
 mail/libraries/helpers.py
 mail/auth.py
 mail/tests/test_auth.py


### PR DESCRIPTION
The test file `test_licence_to_edifact.py` has been updated with a new test `test_single_oiel` which shows that, given a LicencePayload for an OIEL is created, that the `licences_to_edifact` function in `lite_to_edifact_converter.py` handles the LicencePayload correctly and the expected edifact data is produced.

The test file `open_licence_payload_file` is a JSON file based on the existing `licence_payload_file` in the same place for a SIEL. It's a work in progress as we have not finalised the JSON payload from lite-api to send an OIEL to lite-hmrc but this is a first approximation. 

Changes from the SIEL payload include:
- No `end_user` field
- No `goods` list field
- A new `countries` list field with the country data.

This was based on existing OIEL payload data used for OIELs from SPIRE.

None of the existing code for handling SIELs in LITE-HMRC has been changed and everything should work exactly the same even with these changes to the tests.

We can extend the test coverage for OIELs in the `test_licence_to_edifact.py` file once we know a bit more about what we want to test.

EDIT: Additionally `controlled_by` is now set to `"O"` which is actually a requirement for the edifact file that was missed before.
